### PR TITLE
Update value to 4800

### DIFF
--- a/ptpma/encoder_motor.py
+++ b/ptpma/encoder_motor.py
@@ -44,7 +44,7 @@ class PMAEncoderMotor:
     """
 
     MMK_STANDARD_GEAR_RATIO = 41.8
-    MAX_DC_MOTOR_RPM = 6000
+    MAX_DC_MOTOR_RPM = 4800
     _wheel_diameter = 0.075
 
     def __init__(self, port_name, forward_direction, braking_type=BrakingType.COAST, wheel_diameter=0.064):


### PR DESCRIPTION
6000RPM is the max rated RPM of the DC motor without gearing - we found during testing that if the theoretical limit was used and the rover was going full speed, one motor would limit more than the other and it wouldn't go straight. 4800 was a safe value that all DC motors tested could get it. However, in future we need a "torque-limited" function so we know if this is happening and can do something about it properly