### PR TITLE
pt_battery: display help properly

### DIFF
--- a/cli/pt_battery.py
+++ b/cli/pt_battery.py
@@ -47,14 +47,19 @@ def parse_args():
     parser = ArgumentParser(
         description='Get battery information from a pi-top.')
     parser.add_argument("-s", "--charging-state",
-                        help="Get charging state. -1 = No pi-top battery detected, 0 = Discharging, 1 = Charging, 2 = Full battery", action="store_true")
-    parser.add_argument(
-        "-c", "--capacity", help="Get battery capacity percentage (%)", action="store_true")
+                        help="Get charging state. -1 = No pi-top battery detected, 0 = Discharging, 1 = Charging, 2 = Full battery",
+                        action="store_true")
+    parser.add_argument("-c", "--capacity",
+                        help="Get battery capacity percentage (%%)",
+                        action="store_true")
     parser.add_argument("-t", "--time-remaining",
-                        help="Get the time (in minutes) to full or time to empty based on the charging state", action="store_true")
-    parser.add_argument(
-        "-w", "--wattage", help="Get the wattage (mAh) of the battery", action="store_true")
-    parser.add_argument("-v", "--verbose", action="count")
+                        help="Get the time (in minutes) to full or time to empty based on the charging state",
+                        action="store_true")
+    parser.add_argument("-w", "--wattage",
+                        help="Get the wattage (mAh) of the battery",
+                        action="store_true")
+    parser.add_argument("-v", "--verbose",
+                        action="count")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
`Argparser` has issues managing the `%` character in the helper strings (See [1](https://github.com/PyTorchLightning/pytorch-lightning/pull/499), [2](https://stackoverflow.com/questions/21168120/python-argparse-errors-with-in-help-string))

This caused an error when `Argparser` tries to display the `pt-battery` command parameters (by using an unknown parameter or just doing `pt-battery -h`):

```
pi@pi-top:~ $ pt-battery -h
Error getting battery info: unsupported format character ')' (0x29) at index 34
```

The solution is to escape the character properly, fixing `pt-battery -h`:

```
pi@pi-top:~ $ pt-battery -h
usage: pt-battery [-h] [-s] [-c] [-t] [-w] [-v]

Get battery information from a pi-top.

optional arguments:
  -h, --help            show this help message and exit
  -s, --charging-state  Get charging state. -1 = No pi-top battery detected, 0
                        = Discharging, 1 = Charging, 2 = Full battery
  -c, --capacity        Get battery capacity percentage (%)
  -t, --time-remaining  Get the time (in minutes) to full or time to empty
                        based on the charging state
  -w, --wattage         Get the wattage (mAh) of the battery
  -v, --verbose
```