### PR TITLE
Import OLEDImage in pitop.oled

### DIFF
--- a/pitop/oled/__init__.py
+++ b/pitop/oled/__init__.py
@@ -1,4 +1,5 @@
 from .oled_display import PTOLEDDisplay
+from .oled_image import OLEDImage
 from .device_helper import (
     get_device_instance,
     device_reserved,


### PR DESCRIPTION
`OLEDImage` is required in some of the examples.