### PR TITLE
Update motor control registers to match expansion plate labels

### DIFF
--- a/pitop/pma/common/encoder_motor_registers.py
+++ b/pitop/pma/common/encoder_motor_registers.py
@@ -11,7 +11,7 @@ class MotorRegisterTypes:
     ODOMETER = 6
 
 
-EncoderMotorM1 = {
+EncoderMotorM0 = {
     MotorRegisterTypes.CONTROL_MODE: 0x60,
     MotorRegisterTypes.MODE_0_POWER: 0x64,
     MotorRegisterTypes.MODE_1_RPM: 0x68,
@@ -22,7 +22,7 @@ EncoderMotorM1 = {
 }
 
 
-EncoderMotorM2 = {
+EncoderMotorM1 = {
     MotorRegisterTypes.CONTROL_MODE: 0x61,
     MotorRegisterTypes.MODE_0_POWER: 0x65,
     MotorRegisterTypes.MODE_1_RPM: 0x69,
@@ -33,7 +33,7 @@ EncoderMotorM2 = {
 }
 
 
-EncoderMotorM3 = {
+EncoderMotorM2 = {
     MotorRegisterTypes.CONTROL_MODE: 0x62,
     MotorRegisterTypes.MODE_0_POWER: 0x66,
     MotorRegisterTypes.MODE_1_RPM: 0x6A,
@@ -44,7 +44,7 @@ EncoderMotorM3 = {
 }
 
 
-EncoderMotorM4 = {
+EncoderMotorM3 = {
     MotorRegisterTypes.CONTROL_MODE: 0x63,
     MotorRegisterTypes.MODE_0_POWER: 0x67,
     MotorRegisterTypes.MODE_1_RPM: 0x6B,
@@ -56,10 +56,10 @@ EncoderMotorM4 = {
 
 
 class MotorControlRegisters(Enum):
+    M0 = EncoderMotorM0
     M1 = EncoderMotorM1
     M2 = EncoderMotorM2
     M3 = EncoderMotorM3
-    M4 = EncoderMotorM4
 
 
 class MotorControlModes(Enum):

--- a/pitop/pma/encoder_motor_controller.py
+++ b/pitop/pma/encoder_motor_controller.py
@@ -18,7 +18,7 @@ class EncoderMotorController:
 
     def __init__(self, port: str, braking_type: int = 0) -> None:
         if port not in MotorControlRegisters.__members__:
-            raise Exception("Invalid port. Motors must be connected to ports M1-M4")
+            raise Exception("Invalid port. Motors must be connected to ports M0-M3")
 
         self._mcu_device = PlateInterface.instance().get_device_mcu()
         self.registers = MotorControlRegisters[port].value


### PR DESCRIPTION
Motor labels are M0 to M3, not M1 to M4

Given example code uses M3 so this change still compatible with that