### PR TITLE
Improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -5,31 +5,61 @@ about: Report a bug with this project. Make sure you've read "Things To Know Bef
 
 ---
 
-### Things That I, The Bug Reporter, Have Done Before Submitting
-- [ ] I have ensured that this is a bug. Where I was not sure, I checked the [forum](https://forum.pi-top.com/c/pi-top-software), and opened a discussion there.
-- [ ] I have read [Things To Know Before Submitting A Bug Report](https://github.com/pi-top/pi-top-Python-SDK/wiki/Things-To-Know-Before-Submitting-A-Bug-Report) before filling this out.
+<!--
+  ✏️ Fill out the following document, following the template provided by the
+  headings and these comments.
+-->
+
+<!--
+  ⚠️ Before submitting this issue please:
+    - Ensure this is a bug. If you are not sure, check the [forum][1] and open
+        a discussion there.
+    - Ensure this bug or a similar one was not already reported. Check the
+        existing GitHub issues as well as the [forum][1]. If there is a
+        relevant post please add you contributions there instead.
+    - Read [Things To Know Before Submitting A Bug Report][2]
+
+[1]: https://forum.pi-top.com/c/pi-top-software
+[2]: https://github.com/pi-top/pi-top-Python-SDK/wiki/Things-To-Know-Before-Submitting-A-Bug-Report
+-->
 
 ### Summary
-Concise summary of when and how the bug occurred, using code examples where relevant. Include links to related forum posts, if relevant.
-
-### Screenshot/Video Capture
-This may not be relevant, but should be provided where possible. Read [How To Get System Information](https://github.com/pi-top/pi-top-Python-SDK/wiki/How-To-Get-System-Information) for assistance with this.
+<!--
+  🐛📝 Concise summary of the bug. Describe when and how it occurred, using
+  code examples and output logs where relevant. Include links to related forum
+  posts, if relevant.
+-->
 
 ### Expected vs. Actual Results
-What were you expecting to have happen?
+<!--
+  🤔 What were you expecting to have happen?
+-->
 
 ### Steps To Reproduce
-Is it possible to reproduce the bug repeatably? What steps might someone trying to help need to do to see what you are seeing?
+<!--
+  ♻️ Is it possible to reproduce the bug repeatably? What steps might someone
+  trying to help need to do to see what you are seeing?
+-->
 
-### Environment
-Read [How To Get System Information](https://github.com/pi-top/pi-top-Python-SDK/wiki/How-To-Get-System-Information) for assistance with this.
+### Screenshots / Photos / Link to Video
+<!--
+  🖼️ Additional visual information may help to explain the bug and/or how it
+  can be reproduced
+-->
 
-Operating system:
-`pitop` version:
-`pt-device-manager` version:
-Python version:
-Pi model:
-pi-top model:
+### Environment Information
+<!--
+  🖥️ This is valuable to identify the root of the problem. Read [How To Get
+  System Information][3] for assistance with this.
 
-### Logs
-Read [How To Get System Information](https://github.com/pi-top/pi-top-Python-SDK/wiki/How-To-Get-System-Information) for assistance with this. This is valuable to identify the root of the problem.
+[3]: (https://github.com/pi-top/pi-top-Python-SDK/wiki/How-To-Get-System-Information)
+-->
+
+| OS version | `pitop` version | `pitopcommon` version | `pt-device-manager` version | Python version | Pi model | pi-top model |
+| -------------------- | ----- | ----- | ----- | ----- | -- | ------- |
+| pi-topOS Sirius C000 | 0.0.0 | 0.0.0 | 0.0.0 | 0.0.0 | 0A | pi-top0 |
+
+### Additional Context
+<!--
+  ➕ Add other context about the bug here.
+-->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -6,8 +6,14 @@ about: Report a bug with this project. Make sure you've read "Things To Know Bef
 ---
 
 <!--
-  ✏️ Fill out the following document, following the template provided by the
-  headings and these comments.
+  💡 Useful tip: this is a comment!
+
+  Use the information provided in comments as guidance for completing each section.
+
+  Comment sections are not visible in the final submitted Issue.
+  This means you can either delete them or leave them - the output will be the same. Make sure you click "Preview" before you submit, to ensure that you are happy with the formatting.
+
+  ⚠️ Do not add information that you intend to be read by others into comment sections!
 -->
 
 <!--

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -6,18 +6,24 @@ about: Suggest an idea for this project. Make sure you've read "Things To Know B
 ---
 
 <!--
-  ✏️ Fill out the following document, following the template provided by the
-  headings and these comments.
+  💡 Useful tip: this is a comment!
+
+  Use the information provided in comments as guidance for completing each section.
+
+  Comment sections are not visible in the final submitted Issue.
+  This means you can either delete them or leave them - the output will be the same. Make sure you click "Preview" before you submit, to ensure that you are happy with the formatting.
+
+  ⚠️ Do not add information that you intend to be read by others into comment sections!
 -->
 
 <!--
   ⚠️ Before submitting this suggestion please:
-    - Ensure this is a legitimate suggestion. If you are not sure, check the
-        [forum][1] and open a discussion there.
-    - Ensure this suggestion or a similar one was not already made. Check the
+    - Ensure this is a legitimate suggestion. If you are not sure, check the [forum][1] and open
+        a discussion there.
+    - Ensure this suggestion or a similar one has not already been made. Check the
         existing GitHub issues as well as the [forum][1]. If there is a
         relevant post please add you contributions there instead.
-    - Read [Things To Know Before Submitting A Bug Suggestion][2]
+    - Read [Things To Know Before Submitting A Suggestion][2]
 
 [1]: https://forum.pi-top.com/c/pi-top-software
 [2]: https://github.com/pi-top/pi-top-Python-SDK/wiki/Things-To-Know-Before-Submitting-A-Suggestion

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -5,14 +5,41 @@ about: Suggest an idea for this project. Make sure you've read "Things To Know B
 
 ---
 
-### Things That I, The Suggestion Maker, Have Done Before Submitting
-- [ ] I have ensured that this is a legitimate suggestion. Where I was not sure, I checked the [forum](https://forum.pi-top.com/c/pi-top-software), and opened a discussion there.
-- [ ] I have read [Things To Know Before Submitting A Suggestion](https://github.com/pi-top/pi-top-Python-SDK/wiki/Things-To-Know-Before-Submitting-A-Suggestion) before filling this out.
+<!--
+  ✏️ Fill out the following document, following the template provided by the
+  headings and these comments.
+-->
 
-### Summary
-* Clear and concise description of the problem that this suggestion or feature would solve. (For example: "I'm always frustrated when [...]")
-* Description of solution that you would like to see
-* Clear and concise description of any alternative solutions or features you've considered
+<!--
+  ⚠️ Before submitting this suggestion please:
+    - Ensure this is a legitimate suggestion. If you are not sure, check the
+        [forum][1] and open a discussion there.
+    - Ensure this suggestion or a similar one was not already made. Check the
+        existing GitHub issues as well as the [forum][1]. If there is a
+        relevant post please add you contributions there instead.
+    - Read [Things To Know Before Submitting A Bug Suggestion][2]
 
-### Additional context
-Any other context or screenshots about the suggestion here.
+[1]: https://forum.pi-top.com/c/pi-top-software
+[2]: https://github.com/pi-top/pi-top-Python-SDK/wiki/Things-To-Know-Before-Submitting-A-Suggestion
+-->
+
+### Problem or Possibility
+<!--
+  ✨📝 Concise summary of the problem that this suggestion would solve, or the
+  possibility it would enable (For example: "I'm always frustrated when [...]")
+-->
+
+### Proposed Solution
+<!--
+  ✔️ Description of the enhancement that you would like to see
+-->
+
+### Alternative Solutions
+<!--
+  ⭕ Description of any alternative solutions or features you've considered
+-->
+
+### Additional Context
+<!--
+  ➕ Any other context or screenshots about the suggestion here.
+-->


### PR DESCRIPTION
Part of https://github.com/pi-top/pi-top-Python-SDK/issues/42

I picked this up because I started writing a bug report, and actually I resolved my issue in the process of looking up the system info etc, so the process works well, but I thought would still improve it a bit based on that experience.

Both:
- brief explanation of how to fill out the template
- template answers to replace are written in italics to more easily differentiate those from parts that were completed 
- takes out some of the overly formal/patronizing language some people were concerned about

Bug template:
- provide a few more suggestions & prompts for info (eg output logs, photos, additional context)
- only link to the system information page once where it's relevant
- suggest drag & drop of the pt-diagnostics file instead of filling out the system info table

We need to give a bit more thought to the system information page and how users can most helpfully & easily provide system information.

Suggestion template:
- split out summary into full sections
- allow for suggestions that deal with missed possibility rather than a problem

