### PR TITLE
Improve OLED animation handling

### DIFF
--- a/pitop/miniscreen/oled/core/canvas.py
+++ b/pitop/miniscreen/oled/core/canvas.py
@@ -1,6 +1,6 @@
 from os.path import isfile
 from .image_helper import (
-    process_pil_image,
+    process_pil_image_frame,
 )
 from PIL import ImageFont, ImageDraw
 from numpy import reshape
@@ -49,9 +49,9 @@ class Canvas:
         :return: The current canvas pixel map as a 2D array
         :rtype: array
         """
-        image_data = process_pil_image(image,
-                                       size=self.__oled_device.size,
-                                       mode=self.__oled_device.mode)
+        image_data = process_pil_image_frame(image,
+                                             size=self.__oled_device.size,
+                                             mode=self.__oled_device.mode)
         self.draw.bitmap(xy, image_data, 1)
         return self.get_pixels()
 

--- a/pitop/miniscreen/oled/core/image_helper.py
+++ b/pitop/miniscreen/oled/core/image_helper.py
@@ -21,7 +21,7 @@ def get_pil_image_from_path(file_path_or_url):
     return image
 
 
-def process_pil_image(pil_image, size, mode):
+def process_pil_image_frame(pil_image, size, mode):
     staging_data = Image.new("RGB", size, "black")
     staging_data.paste(pil_image.resize(size))
 

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -147,12 +147,12 @@ class OLED:
 
     def draw_image_file(self, file_path_or_url, xy=None):
         """
-        Renders a static image file to the screen at a given position.
+        Render a static image to the screen from a file or URL at a given position.
 
         The helper methods in the `pitop.miniscreen.oled.core.Canvas` class can be used to specify the
         `xy` position parameter, e.g. `top_left`, `top_right`.
 
-        :param Image image: A PIL Image object to be rendered
+        :param str file_path_or_url: A file path or URL to the image
         :param tuple xy: The position on the screen to render the image. If not
             provided or passed as `None` the image will be drawn in the top-left of
             the screen.
@@ -162,10 +162,9 @@ class OLED:
 
     def draw_image(self, image, xy=None):
         """
-        Renders an image to the screen at a given position.
+        Render a static image to the screen from a file or URL at a given position.
 
-        The image should be provided as a PIL Image object, which can be
-        used to animate an image with frames (e.g. an animated gif).
+        The image should be provided as a PIL Image object.
 
         The helper methods in the `pitop.miniscreen.oled.core.Canvas` class can be used to specify the
         `xy` position parameter, e.g. `top_left`, `top_right`.
@@ -262,11 +261,13 @@ class OLED:
 
     def play_animated_image_file(self, file_path_or_url, background=False, loop=False):
         """
-        Render an animation or a image to the screen.
+        Render an animated image to the screen from a file or URL.
 
-        :param Image image: A PIL Image object to be rendered
+        :param str file_path_or_url: A file path or URL to the image
         :param bool background: Set whether the image should be in a background thread
             or in the main thread.
+        :param bool loop: Set whether the image animation should start again when it
+            has finished
         """
         image = get_pil_image_from_path(file_path_or_url)
         self.play_animated_image(image, background, loop)
@@ -275,9 +276,13 @@ class OLED:
         """
         Render an animation or a image to the screen.
 
+        Use stop_animated_image() to end a background animation
+
         :param Image image: A PIL Image object to be rendered
         :param bool background: Set whether the image should be in a background thread
             or in the main thread.
+        :param bool loop: Set whether the image animation should start again when it
+            has finished
         """
         self.__kill_thread = False
         if background is True:

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -10,10 +10,9 @@ from .core.canvas import Canvas
 from .core.fps_regulator import FPS_Regulator
 from .core.image_helper import (
     get_pil_image_from_path,
-    process_pil_image,
+    process_pil_image_frame,
 )
 
-from pitopcommon.sys_info import is_pi
 from pitopcommon.ptdm import (
     PTDMSubscribeClient,
     Message,
@@ -23,6 +22,7 @@ import atexit
 from copy import deepcopy
 from PIL import Image, ImageSequence
 from threading import Thread
+from time import sleep
 
 
 class OLED:
@@ -127,8 +127,7 @@ class OLED:
         Gives the caller access to the OLED screen (i.e. in the case the the system is
         currently rendering information to the screen) and clears the screen.
         """
-        if is_pi():
-            self.set_control_to_pi()
+        self.set_control_to_pi()
         self.canvas.clear()
 
         _reset_device()
@@ -139,19 +138,14 @@ class OLED:
 
         self.show()
 
-    def get_raw_image(self, file_path_or_url):
-        return get_pil_image_from_path(file_path_or_url)
-
-    def get_processed_image(self, file_path_or_url):
-        image = self.get_raw_image(file_path_or_url)
-
-        return process_pil_image(
+    def __process_image_frame(self, image):
+        return process_pil_image_frame(
             image,
             self.device.size,
             self.device.mode
         )
 
-    def draw_image_file(self, file_path, xy=None):
+    def draw_image_file(self, file_path_or_url, xy=None):
         """
         Renders a static image file to the screen at a given position.
 
@@ -163,8 +157,8 @@ class OLED:
             provided or passed as `None` the image will be drawn in the top-left of
             the screen.
         """
-        image = self.get_processed_image(file_path)
-        self.draw_image(image, xy)
+        image = get_pil_image_from_path(file_path_or_url)
+        self.draw_image(self.__process_image_frame(image), xy)
 
     def draw_image(self, image, xy=None):
         """
@@ -266,6 +260,17 @@ class OLED:
         self.fps_regulator.start_timer()
         self._previous_frame = Canvas(self.device, deepcopy(self.image))
 
+    def play_animated_image_file(self, file_path_or_url, background=False, loop=False):
+        """
+        Render an animation or a image to the screen.
+
+        :param Image image: A PIL Image object to be rendered
+        :param bool background: Set whether the image should be in a background thread
+            or in the main thread.
+        """
+        image = get_pil_image_from_path(file_path_or_url)
+        self.play_animated_image(image, background, loop)
+
     def play_animated_image(self, image, background=False, loop=False):
         """
         Render an animation or a image to the screen.
@@ -274,10 +279,10 @@ class OLED:
         :param bool background: Set whether the image should be in a background thread
             or in the main thread.
         """
-        self._kill_thread = False
+        self.__kill_thread = False
         if background is True:
             self.auto_play_thread = Thread(
-                target=self.__auto_play, args=(image,))
+                target=self.__auto_play, args=(image, loop))
             self.auto_play_thread.start()
         else:
             self.__auto_play(image)
@@ -287,15 +292,24 @@ class OLED:
         Stop background animation started using `start()`, if currently running.
         """
         if self.auto_play_thread is not None:
-            self._kill_thread = True
+            self.__kill_thread = True
             self.auto_play_thread.join()
 
     def __auto_play(self, image, loop=False):
         while True:
             for frame in ImageSequence.Iterator(image):
-                if self._kill_thread:
-                    break
-                self.draw_image(image)
 
-            if not loop:
+                if self.__kill_thread:
+                    break
+
+                self.draw_image(
+                    self.__process_image_frame(frame)
+                )
+                # Wait for animated image's frame length
+                sleep(
+                    float(frame.info["duration"] / 1000)  # ms to s
+                )
+
+            if self.__kill_thread or not loop:
+                self.reset()
                 break

--- a/pitopcli/oled.py
+++ b/pitopcli/oled.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from time import sleep
 from os.path import isfile
-from PIL import ImageSequence
 
 from pitopcommon.formatting import is_url
 
@@ -37,13 +36,7 @@ class OledCLI(CliBaseClass):
 
                 skip_timeout = False
                 if isfile(self.args.text) or is_url(self.args.text):
-                    oled.set_max_fps(10)
-                    img = oled.get_raw_image(self.args.text)
-                    skip_timeout = is_animated(img)
-
-                    for i in range(self.args.loop):
-                        for frame in ImageSequence.Iterator(img):
-                            oled.draw_image(frame)
+                    oled.play_animated_image_file(self.args.text)
                 else:
                     oled.draw_multiline_text(self.args.text, font_size=self.args.font_size)
 


### PR DESCRIPTION
Images (including animated ones) can now be sent without any pre-processing for the OLED from a file path, URL or PIL image and should render correctly.
CLI now uses API for animation directly.
Animations respect GIF frame lengths.
