### PR TITLE
Improve CLI messages on missing arguments

### DIFF
--- a/pitopcli/cli_base.py
+++ b/pitopcli/cli_base.py
@@ -5,6 +5,10 @@ class PitopCliException(Exception):
     pass
 
 
+class PitopCliInvalidArgument(Exception):
+    pass
+
+
 class CliBaseClass(ABC):
     """Abstract class, used to create CLI commands"""
     @abstractmethod
@@ -41,4 +45,13 @@ class CliBaseClass(ABC):
     @abstractproperty
     def cli_name(self):
         """Name of the class CLI, without the 'pt-' prefix"""
+        pass
+
+    @property
+    def parser(self):
+        """ArgumentParser object used to parse the class"""
+        pass
+
+    def validate_args(self):
+        """Method to perform further validation on arguments"""
         pass

--- a/pitopcli/display.py
+++ b/pitopcli/display.py
@@ -2,7 +2,7 @@
 from argparse import ArgumentParser
 
 from pitop.display import Display
-from .cli_base import CliBaseClass, PitopCliException
+from .cli_base import CliBaseClass, PitopCliException, PitopCliInvalidArgument
 
 
 class DisplayCLI(CliBaseClass):
@@ -18,18 +18,20 @@ class DisplayCLI(CliBaseClass):
             self.perform_desired_action()
             return 0
         except Exception as e:
-            print(f"Error on pitop-brightness.run: {e}")
+            print(f"Error on pitop-display.run: {e}")
             return 1
 
     def validate_args(self) -> None:
+        if vars(self.args).get('display_subcommand') is None:
+            raise PitopCliInvalidArgument
         # Handle invalid command line parameter combinations
         if self.args.display_subcommand != "brightness":
             return
         if self.args.brightness_value and (self.args.increment_brightness or self.args.decrement_brightness):
-            print("Error on pitop-brightness.validate_args: Cannot increment/decrement at the same time as setting brightness value")
+            print("Error on pitop-display.validate_args: Cannot increment/decrement at the same time as setting brightness value")
             raise PitopCliException
         if self.args.increment_brightness and self.args.decrement_brightness:
-            print("Error on pitop-brightness.validate_args: Cannot increment and decrement brightness at the same time")
+            print("Error on pitop-display.validate_args: Cannot increment and decrement brightness at the same time")
             raise PitopCliException
 
     def perform_desired_action(self) -> None:
@@ -61,7 +63,6 @@ class DisplayCLI(CliBaseClass):
     def add_parser_arguments(cls, parser) -> None:
         subparser = parser.add_subparsers(title="pi-top display utility",
                                           description="Interface to communicate with the device's display",
-                                          required=True,
                                           dest="display_subcommand")
 
         # "pi-top display brightness"

--- a/pitopcli/oled.py
+++ b/pitopcli/oled.py
@@ -5,7 +5,7 @@ from os.path import isfile
 from pitopcommon.formatting import is_url
 
 from pitop.miniscreen import OLED
-from .cli_base import CliBaseClass
+from .cli_base import CliBaseClass, PitopCliInvalidArgument
 
 
 class OledCLI(CliBaseClass):
@@ -14,9 +14,15 @@ class OledCLI(CliBaseClass):
 
     def __init__(self, args) -> None:
         self.args = args
+        self.validate_args()
+
         # TODO: add support for 'give/take control to/from hub'
         # REQ_GET_OLED_CONTROL = 125
         # REQ_SET_OLED_CONTROL = 126
+
+    def validate_args(self) -> None:
+        if self.args.oled_subcommand is None:
+            raise PitopCliInvalidArgument
 
     def run(self) -> int:
         def is_animated(image):
@@ -60,7 +66,7 @@ class OledCLI(CliBaseClass):
         parser_draw = subparser.add_parser("draw", help="Draw text and images into the OLED")
         parser_draw.add_argument("--force", "-f",
                                  help="Force the hub to give control of the OLED to the Pi",
-                                 action="store_true"
+                                 action="store_false"
                                  )
         parser_draw.add_argument("--timeout", "-t",
                                  type=int,
@@ -84,7 +90,7 @@ class OledCLI(CliBaseClass):
         parser_capture = subparser.add_parser("capture", help="Capture images or videos of the OLED content")
         parser_capture.add_argument("--force", "-f",
                                     help="Force the hub to give control of the OLED to the Pi",
-                                    action="store_true"
+                                    action="store_false"
                                     )
 
 

--- a/pitopcli/pitop.py
+++ b/pitopcli/pitop.py
@@ -12,10 +12,8 @@ from .cli_base import PitopCliException, PitopCliInvalidArgument
 
 lookup_dict = {
     "battery": BatteryCLI,
-    "brightness": DisplayCLI,
     "devices": DeviceCLI,
     "display": DisplayCLI,
-    "host": DeviceCLI,
     "oled": OledCLI
 }
 


### PR DESCRIPTION
- Remove deprecated CLI subcommands from `pi-top`
- Print usage help message if CLI subcommands are not provided

## Preview

```
(venv) pi@pi-top:~/pi-top-Python-API $ pt
usage: pi-top [-h] {battery,devices,display,oled} ...

optional arguments:
  -h, --help            show this help message and exit

Subcommands:
  Set of valid subcommands to use to interface with your pi-top

  {battery,devices,display,oled}
                        valid subcommands
    battery             Get battery information from a pi-top
    devices             Get information about device and attached pi-top
                        hardware
    display             communicate and control the device's display
    oled                pi-top OLED quick text
```

```
(venv) pi@pi-top:~/pi-top-Python-API $ pt display
usage: pi-top display [-h] {brightness,backlight,blank_time} ...

optional arguments:
  -h, --help            show this help message and exit

pi-top display utility:
  Interface to communicate with the device's display

  {brightness,backlight,blank_time}
    brightness          Control display brightness
    backlight           Control display backlight
    blank_time          Set the time before the screen goes blank on
                        inactivity (0 to disable)
```