### PR TITLE
Patch Ultrasonic Sensor

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 py-pitop-sdk (0.14.0) buster; urgency=medium
 
   * Buttons can only be used by a single process
+  * Suppress ultrasonic sensor warning messages
 
  -- Jorge Capona <jorge@pi-top.com>  Mon, 25 Jan 2021 16:17:48 -0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ py-pitop-sdk (0.14.0) buster; urgency=medium
 
   * Buttons can only be used by a single process
   * Suppress ultrasonic sensor warning messages
+  * Increase ultrasonic sensor detection range
 
  -- Jorge Capona <jorge@pi-top.com>  Mon, 25 Jan 2021 16:17:48 -0300
 

--- a/pitop/pma/ultrasonic_sensor.py
+++ b/pitop/pma/ultrasonic_sensor.py
@@ -213,7 +213,7 @@ class UltrasonicSensor(SmoothedInputDevice):
                 # The echo pin never rose or fell - assume that distance is max
                 PTLogger.debug(f"Ultrasonic Sensor on port {self._pma_port} - "
                                "no echo received, using max distance ")
-                return self._max_distance
+                return 1.0
 
     @property
     def in_range(self):


### PR DESCRIPTION
Increase timeout for echo pin from 100ms to 200ms. @jcapona says that this is allowing him to get higher distances, whereas I am not getting above ~60cm.

Gpiozero warnings are now debug prints.

We hide `RuntimeError: could not find io module state (interpreter shutdown?)` errors from native factory, until we have found a way to effectively manage this. The best solution would be to go from native factory back to RPi.GPIO, but this is not working well with luma, the OLED's internal library, as this leads to the "mixing libraries" issue described here: https://github.com/gpiozero/gpiozero/issues/783

If we don't get a response back from the echo pin, then we assume that distance is max.