### PR TITLE
Rework miniscreen lock files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+py-pitop-sdk (0.14.0) buster; urgency=medium
+
+  * Buttons can only be used by a single process
+
+ -- Jorge Capona <jorge@pi-top.com>  Mon, 25 Jan 2021 16:17:48 -0300
+
 py-pitop-sdk (0.13.3) buster; urgency=medium
 
   * Convert image to array before checking dimensional size for RGB conversion

--- a/pitop/miniscreen/oled/core/device_controller.py
+++ b/pitop/miniscreen/oled/core/device_controller.py
@@ -42,6 +42,8 @@ class OledDeviceController:
 
         atexit.register(self.__clean_up)
 
+        self.get_device()
+
     def __setup_subscribe_client(self):
         def on_spi_bus_changed(parameters):
             self.__spi_bus = int(parameters[0])
@@ -97,15 +99,11 @@ class OledDeviceController:
     ##############################
 
     def device_is_active(self):
-        if (self.__exclusive_mode is True and self.__device is not None):
-            # We already have the device, so no-one else can
-            return False
-
         return self.lock.is_locked()
 
     def reset_device(self):
         self.__device = None
-        if self.lock.is_locked():
+        if self.device_is_active():
             self.lock.release()
 
     def get_device(self):

--- a/pitop/miniscreen/oled/core/device_controller.py
+++ b/pitop/miniscreen/oled/core/device_controller.py
@@ -42,8 +42,6 @@ class OledDeviceController:
 
         atexit.register(self.__clean_up)
 
-        self.get_device()
-
     def __setup_subscribe_client(self):
         def on_spi_bus_changed(parameters):
             self.__spi_bus = int(parameters[0])


### PR DESCRIPTION
Buttons can now only be used by a single process, and use a globally recognised buttons lock file, similar to how the OLED works. `Buttons.is_active` can be used by sys oled to determine if it is active with the user.