### PR TITLE
Fix text wrapping when displaying multiline text in OLED

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,8 +82,7 @@ modules available in the library:
     utrasonic = PMAUltrasonicSensor("D1")
 
     while True:
-        distance = utrasonic.distance
-        miniscreen.display_multiline_text(distance)
+        miniscreen.display_multiline_text(utrasonic.distance)
         sleep(0.1)
 
 Check out the `API Recipes`_ chapter of the documentation for ideas on how to get started.

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ modules available in the library:
 
     while True:
         distance = utrasonic.distance
-        miniscreen.display_multiline_text(str(distance))
+        miniscreen.display_multiline_text(distance)
         sleep(0.1)
 
 Check out the `API Recipes`_ chapter of the documentation for ideas on how to get started.

--- a/README.rst
+++ b/README.rst
@@ -79,10 +79,10 @@ modules available in the library:
     from pitop.miniscreen import Miniscreen
 
     miniscreen = Miniscreen()
-    utrasonic = PMAUltrasonicSensor("D1")
+    utrasonic = UltrasonicSensor("D1")
 
     while True:
-        miniscreen.display_multiline_text(utrasonic.distance)
+        miniscreen.display_text(utrasonic.distance)
         sleep(0.1)
 
 Check out the `API Recipes`_ chapter of the documentation for ideas on how to get started.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+py-pitop-sdk (0.15.1) buster; urgency=medium
+
+  * Fix text wrapping when displaying multiline text
+
+ -- Jorge Capona <jorge@pi-top.com>  Mon, 01 Feb 2021 12:44:45 -0300
+
 py-pitop-sdk (0.15.0) buster; urgency=medium
 
   * Docs update and refactor

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,10 +56,10 @@ modules available in the library:
     from pitop.miniscreen import Miniscreen
 
     miniscreen = Miniscreen()
-    utrasonic = PMAUltrasonicSensor("D1")
+    utrasonic = UltrasonicSensor("D1")
 
     while True:
-        miniscreen.display_multiline_text(utrasonic.distance)
+        miniscreen.display_text(utrasonic.distance)
         sleep(0.1)
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,7 @@ modules available in the library:
 
     while True:
         distance = utrasonic.distance
-        miniscreen.display_multiline_text(str(distance))
+        miniscreen.display_multiline_text(distance)
         sleep(0.1)
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,8 +59,7 @@ modules available in the library:
     utrasonic = PMAUltrasonicSensor("D1")
 
     while True:
-        distance = utrasonic.distance
-        miniscreen.display_multiline_text(distance)
+        miniscreen.display_multiline_text(utrasonic.distance)
         sleep(0.1)
 
 

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -318,7 +318,7 @@ class OLED:
         # 'Draw' text to empty image, using desired font size
         ImageDraw.Draw(image).text(
             xy,
-            text,
+            str(text),
             font=ImageFont.truetype(
                 self.__font_path(),
                 size=font_size
@@ -364,7 +364,7 @@ class OLED:
         def format_multiline_text(text):
             def get_text_size(text):
                 return ImageDraw.Draw(self.__empty_image).textsize(
-                    text=text,
+                    text=str(text),
                     font=font,
                     spacing=0,
                 )
@@ -395,7 +395,7 @@ class OLED:
         # 'Draw' text to empty image, using desired font size
         ImageDraw.Draw(image).multiline_text(
             xy,
-            text,
+            str(text),
             font=font,
             fill=1,
             spacing=0,


### PR DESCRIPTION
Also ensure that text can be displayed with `str()`