### PR TITLE
Use environment variable for miniscreen non-'exclusive mode'

### DIFF
--- a/pitop/miniscreen/buttons/buttons.py
+++ b/pitop/miniscreen/buttons/buttons.py
@@ -43,7 +43,7 @@ class Buttons(metaclass=Singleton):
 
         self.lock = PTLock("pt-buttons")
 
-        if getenv('PT_MINISCREEN_SYSTEM', 0) != "1":
+        if getenv('PT_MINISCREEN_SYSTEM', "0") != "1":
             self.lock.acquire()
 
     @property

--- a/pitop/miniscreen/buttons/buttons.py
+++ b/pitop/miniscreen/buttons/buttons.py
@@ -7,6 +7,7 @@ from pitopcommon.ptdm import (
 from pitopcommon.lock import PTLock
 from pitopcommon.singleton import Singleton
 
+from os import getenv
 import atexit
 
 
@@ -29,13 +30,11 @@ class Buttons(metaclass=Singleton):
     SELECT = "SELECT"
     CANCEL = "CANCEL"
 
-    def __init__(self, _exclusive_mode=True):
+    def __init__(self):
         self.up = MiniscreenButtonLegacy(self.UP)
         self.down = MiniscreenButtonLegacy(self.DOWN)
         self.select = MiniscreenButtonLegacy(self.SELECT)
         self.cancel = MiniscreenButtonLegacy(self.CANCEL)
-
-        self.__exclusive_mode = _exclusive_mode
 
         self.__ptdm_subscribe_client = None
         self.__setup_subscribe_client()
@@ -43,7 +42,8 @@ class Buttons(metaclass=Singleton):
         atexit.register(self.__clean_up)
 
         self.lock = PTLock("pt-buttons")
-        if self.__exclusive_mode:
+
+        if getenv('PT_SDK_MINISCREEN_SYSTEM', 0) != 1:
             self.lock.acquire()
 
     @property

--- a/pitop/miniscreen/buttons/buttons.py
+++ b/pitop/miniscreen/buttons/buttons.py
@@ -43,7 +43,7 @@ class Buttons(metaclass=Singleton):
 
         self.lock = PTLock("pt-buttons")
 
-        if getenv('PT_SDK_MINISCREEN_SYSTEM', 0) != 1:
+        if getenv('PT_MINISCREEN_SYSTEM', 0) != "1":
             self.lock.acquire()
 
     @property

--- a/pitop/miniscreen/miniscreen.py
+++ b/pitop/miniscreen/miniscreen.py
@@ -15,8 +15,8 @@ class Miniscreen(OLED):
     See :class:`pitop.miniscreen.MiniscreenButton` for how to use these buttons.
     """
 
-    def __init__(self, _exclusive_mode=True):
-        super(Miniscreen, self).__init__(_exclusive_mode)
+    def __init__(self):
+        super(Miniscreen, self).__init__()
 
         self._up_button = MiniscreenButton()
         self._down_button = MiniscreenButton()

--- a/pitop/miniscreen/oled/core/device_controller.py
+++ b/pitop/miniscreen/oled/core/device_controller.py
@@ -68,7 +68,7 @@ class OledDeviceController:
             request_client.send_message(message)
 
     def __setup_device(self):
-        if getenv('PT_MINISCREEN_SYSTEM', 0) != "1":
+        if getenv('PT_MINISCREEN_SYSTEM', "0") != "1":
             self.lock.acquire()
             atexit.register(self.reset_device)
 

--- a/pitop/miniscreen/oled/core/device_controller.py
+++ b/pitop/miniscreen/oled/core/device_controller.py
@@ -68,7 +68,7 @@ class OledDeviceController:
             request_client.send_message(message)
 
     def __setup_device(self):
-        if getenv('PT_SDK_MINISCREEN_SYSTEM', 0) != 1:
+        if getenv('PT_MINISCREEN_SYSTEM', 0) != "1":
             self.lock.acquire()
             atexit.register(self.reset_device)
 

--- a/pitop/miniscreen/oled/core/device_controller.py
+++ b/pitop/miniscreen/oled/core/device_controller.py
@@ -7,6 +7,8 @@ from pitopcommon.ptdm import (
     PTDMSubscribeClient,
 )
 
+from os import getenv
+
 from luma.core.interface.serial import spi
 from luma.oled.device import sh1106
 
@@ -30,11 +32,10 @@ class OledDeviceController:
     #
     # this is only necessary to support users with SPI0 on device
     # with older SDK version that only supported SPI1
-    def __init__(self, redraw_last_image_func, exclusive_mode):
+    def __init__(self, redraw_last_image_func):
         self.__redraw_last_image_func = redraw_last_image_func
         self.__spi_bus = self.__get_spi_bus_from_ptdm()
         self.__device = None
-        self.__exclusive_mode = exclusive_mode
         self.lock = PTLock("pt-oled")
 
         self.__ptdm_subscribe_client = None
@@ -67,7 +68,7 @@ class OledDeviceController:
             request_client.send_message(message)
 
     def __setup_device(self):
-        if self.__exclusive_mode:
+        if getenv('PT_SDK_MINISCREEN_SYSTEM', 0) != 1:
             self.lock.acquire()
             atexit.register(self.reset_device)
 

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -34,9 +34,8 @@ class OLED:
 
     __LOCK_FILE_PATH = "/tmp/pt-oled.lock"
 
-    # Exclusive mode only intended to be used privately (pt-sys-oled, some CLI operations)
-    def __init__(self, _exclusive_mode=True):
-        self.__controller = OledDeviceController(self._redraw_last_image, _exclusive_mode)
+    def __init__(self):
+        self.__controller = OledDeviceController(self._redraw_last_image)
 
         self.image = self.__empty_image
 

--- a/pitopcli/oled.py
+++ b/pitopcli/oled.py
@@ -39,8 +39,7 @@ class OledCLI(CliBaseClass):
 
         try:
             if self.args.oled_subcommand == "display":
-                # Do take control of OLED to display
-                oled = Miniscreen(_exclusive_mode=True)
+                oled = Miniscreen()
 
                 if self.args.force:
                     oled.set_control_to_pi()
@@ -61,8 +60,7 @@ class OledCLI(CliBaseClass):
                     pass
 
             elif self.args.oled_subcommand == "spi":
-                # Do not take control of OLED just to change its internal state
-                oled = Miniscreen(_exclusive_mode=False)
+                oled = Miniscreen()
 
                 if self.args.spi_bus is not None:
                     oled.spi_bus = self.args.spi_bus


### PR DESCRIPTION
This simplifies what is exposed to the user. `pt-sys-oled` will use an environment variable to get its desired behaviour.