### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -23,7 +23,8 @@ jobs:
 
   add-version-tag:
     needs: [ get-ci-changelog-branch-name ]
-    if: github.head_ref == needs.get-ci-changelog-branch-name.outputs.ci_changelog_bump_branch && github.event.pull_request.merged == true
+    if: github.head_ref != needs.get-ci-changelog-branch-name.outputs.ci_changelog_bump_branch
+    # if: github.head_ref == needs.get-ci-changelog-branch-name.outputs.ci_changelog_bump_branch && github.event.pull_request.merged == true
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ci-test-fix-release]
 
+env:
+  CI_CHANGELOG_BUMP_BRANCH: ${{secrets.CI_CHANGELOG_BUMP_BRANCH}}
+
 jobs:
   get-ci-changelog-branch-name:
     runs-on: ubuntu-20.04
@@ -16,7 +19,7 @@ jobs:
     steps:
       - name: Assign CI changelog bump branch to output variable - required for conditional check
         id: secret
-        run: echo '::set-output name=ci_changelog_bump_branch::${{secrets.CI_CHANGELOG_BUMP_BRANCH}}'
+        run: echo '::set-output name=ci_changelog_bump_branch::${{env.CI_CHANGELOG_BUMP_BRANCH}}'
 
   add-version-tag:
     needs: [ get-ci-changelog-branch-name ]

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -9,7 +9,7 @@ on:
     branches: [ci-test-fix-release]
 
 # env:
-#   CI_CHANGELOG_BUMP_BRANCH: ${{ secrets.CI_CHANGELOG_BUMP_BRANCH }}
+  # CI_CHANGELOG_BUMP_BRANCH: ${{ secrets.CI_CHANGELOG_BUMP_BRANCH }}
 
 jobs:
   add-version-tag:
@@ -20,9 +20,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Assign variable
+        id: secret
+        run: echo '::set-output name=ci_changelog_bump_branch::${{secrets.CI_CHANGELOG_BUMP_BRANCH}}'
+
+      - name: Encode the project the project
+
+
       - name: Create and push Debian version tag
         # if: github.head_ref == env.CI_CHANGELOG_BUMP_BRANCH && github.event.pull_request.merged == true
-        if: secrets.CI_CHANGELOG_BUMP_BRANCH == ci-update-changelog-next-release
+        if: steps.secret.outputs.ci_changelog_bump_branch == ci-update-changelog-next-release
+        # if: github.head_ref == steps.secret.outputs.ci_changelog_bump_branch && github.event.pull_request.merged == true
         run: |
           new_version="$(head -n1 debian/changelog | awk '{print $2}' | cut -d'-' -f1 | sed "s/(//g" | sed "s/)//g")"
           git tag "v${new_version}"

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -8,8 +8,8 @@ on:
   push:
     branches: [ci-test-fix-release]
 
-env:
-  CI_CHANGELOG_BUMP_BRANCH: ${{ secrets.CI_CHANGELOG_BUMP_BRANCH }}
+# env:
+#   CI_CHANGELOG_BUMP_BRANCH: ${{ secrets.CI_CHANGELOG_BUMP_BRANCH }}
 
 jobs:
   add-version-tag:
@@ -21,8 +21,8 @@ jobs:
           fetch-depth: 0
 
       - name: Create and push Debian version tag
-        # if: ${{ github.head_ref }} == ${{ env.CI_CHANGELOG_BUMP_BRANCH }} && ${{ github.event.pull_request.merged }} == true
-        if: ${{ env.CI_CHANGELOG_BUMP_BRANCH }} == "ci-update-changelog-next-release"
+        # if: github.head_ref == env.CI_CHANGELOG_BUMP_BRANCH && github.event.pull_request.merged == true
+        if: secrets.CI_CHANGELOG_BUMP_BRANCH == ci-update-changelog-next-release
         run: |
           new_version="$(head -n1 debian/changelog | awk '{print $2}' | cut -d'-' -f1 | sed "s/(//g" | sed "s/)//g")"
           git tag "v${new_version}"

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -24,9 +24,6 @@ jobs:
         id: secret
         run: echo '::set-output name=ci_changelog_bump_branch::${{secrets.CI_CHANGELOG_BUMP_BRANCH}}'
 
-      - name: Encode the project the project
-
-
       - name: Create and push Debian version tag
         # if: github.head_ref == env.CI_CHANGELOG_BUMP_BRANCH && github.event.pull_request.merged == true
         if: steps.secret.outputs.ci_changelog_bump_branch == ci-update-changelog-next-release

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -8,23 +8,22 @@ on:
   push:
     branches: [ci-test-fix-release]
 
-env:
-  CI_CHANGELOG_BUMP_BRANCH: ${{secrets.CI_CHANGELOG_BUMP_BRANCH}}
-
 jobs:
-  get-ci-changelog-branch-name:
+  get-should-run:
     runs-on: ubuntu-20.04
     outputs:
-      ci_changelog_bump_branch: ${{ steps.secret.outputs.ci_changelog_bump_branch }}
+      should_run: ${{ steps.secret.outputs.should_run }}
     steps:
-      - name: Assign CI changelog bump branch to output variable - required for conditional check
+
+      - name: Set should run variable
+        # if: github.head_ref == needs.get-ci-changelog-branch-name.outputs.should_run && github.event.pull_request.merged == true
         id: secret
-        run: echo '::set-output name=ci_changelog_bump_branch::${{env.CI_CHANGELOG_BUMP_BRANCH}}'
+        run: |
+          echo '::set-output name=should_run::false'
 
   add-version-tag:
     needs: [ get-ci-changelog-branch-name ]
-    if: github.head_ref != needs.get-ci-changelog-branch-name.outputs.ci_changelog_bump_branch
-    # if: github.head_ref == needs.get-ci-changelog-branch-name.outputs.ci_changelog_bump_branch && github.event.pull_request.merged == true
+    if: needs.get-should-run.outputs.should_run == 'true'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -3,10 +3,6 @@ name: Create Draft GitHub Release And Tag On Merging Changelog PR
 on:
   pull_request:
     types: [closed]
-  # This is temporary to ensure that the commit _after_ this was meant to run will trigger it
-  # This should be removed immediately after the pipeline is fixed
-  push:
-    branches: [ci-test-fix-release]
 
 jobs:
   check-should-run:

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -9,20 +9,28 @@ on:
     branches: [ci-test-fix-release]
 
 jobs:
-  get-should-run:
+  check-should-run:
     runs-on: ubuntu-20.04
     outputs:
-      should_run: ${{ steps.secret.outputs.should_run }}
+      should_run: ${{ steps.check_should_run.outputs.should_run }}
     steps:
 
-      - name: Set should run variable
-        # if: github.head_ref == needs.get-ci-changelog-branch-name.outputs.should_run && github.event.pull_request.merged == true
-        id: secret
+      - name: Set 'should run' variable
+        id: check_should_run
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          CI_CHANGELOG_BUMP_BRANCH: ${{ secrets.CI_CHANGELOG_BUMP_BRANCH }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          echo '::set-output name=should_run::true'
+          if [[ "${HEAD_REF}" == "${CI_CHANGELOG_BUMP_BRANCH}" ]] && [[ "${PR_MERGED}" == "true" ]];
+            conditions_met="true"
+          else
+            conditions_met="false"
+          fi
+          echo "::set-output name=should_run::${conditions_met}"
 
   add-version-tag:
-    needs: [ get-should-run ]
+    needs: [ check-should-run ]
     if: needs.get-should-run.outputs.should_run == 'true'
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -8,11 +8,19 @@ on:
   push:
     branches: [ci-test-fix-release]
 
-# env:
-  # CI_CHANGELOG_BUMP_BRANCH: ${{ secrets.CI_CHANGELOG_BUMP_BRANCH }}
-
 jobs:
+  get-ci-changelog-branch-name:
+    runs-on: ubuntu-20.04
+    outputs:
+      ci_changelog_bump_branch: ${{ steps.secret.outputs.ci_changelog_bump_branch }}
+    steps:
+      - name: Assign CI changelog bump branch to output variable - required for conditional check
+        id: secret
+        run: echo '::set-output name=ci_changelog_bump_branch::${{secrets.CI_CHANGELOG_BUMP_BRANCH}}'
+
   add-version-tag:
+    needs: [ get-ci-changelog-branch-name ]
+    if: github.head_ref == needs.get-ci-changelog-branch-name.outputs.ci_changelog_bump_branch && github.event.pull_request.merged == true
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -20,14 +28,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Assign variable
-        id: secret
-        run: echo '::set-output name=ci_changelog_bump_branch::${{secrets.CI_CHANGELOG_BUMP_BRANCH}}'
-
       - name: Create and push Debian version tag
-        # if: github.head_ref == env.CI_CHANGELOG_BUMP_BRANCH && github.event.pull_request.merged == true
-        if: steps.secret.outputs.ci_changelog_bump_branch == 'ci-update-changelog-next-release'
-        # if: github.head_ref == steps.secret.outputs.ci_changelog_bump_branch && github.event.pull_request.merged == true
         run: |
           new_version="$(head -n1 debian/changelog | awk '{print $2}' | cut -d'-' -f1 | sed "s/(//g" | sed "s/)//g")"
           git tag "v${new_version}"

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -22,7 +22,7 @@ jobs:
           CI_CHANGELOG_BUMP_BRANCH: ${{ secrets.CI_CHANGELOG_BUMP_BRANCH }}
           PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          if [[ "${HEAD_REF}" == "${CI_CHANGELOG_BUMP_BRANCH}" ]] && [[ "${PR_MERGED}" == "true" ]];
+          if [[ "${HEAD_REF}" == "${CI_CHANGELOG_BUMP_BRANCH}" ]] && [[ "${PR_MERGED}" == "true" ]]; then
             conditions_met="true"
           else
             conditions_met="false"

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create and push Debian version tag
         # if: github.head_ref == env.CI_CHANGELOG_BUMP_BRANCH && github.event.pull_request.merged == true
-        if: steps.secret.outputs.ci_changelog_bump_branch == ci-update-changelog-next-release
+        if: steps.secret.outputs.ci_changelog_bump_branch == 'ci-update-changelog-next-release'
         # if: github.head_ref == steps.secret.outputs.ci_changelog_bump_branch && github.event.pull_request.merged == true
         run: |
           new_version="$(head -n1 debian/changelog | awk '{print $2}' | cut -d'-' -f1 | sed "s/(//g" | sed "s/)//g")"

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -6,15 +6,13 @@ on:
   # This is temporary to ensure that the commit _after_ this was meant to run will trigger it
   # This should be removed immediately after the pipeline is fixed
   push:
-    branches: [master]
+    branches: [ci-test-fix-release]
 
 env:
   CI_CHANGELOG_BUMP_BRANCH: ${{ secrets.CI_CHANGELOG_BUMP_BRANCH }}
 
 jobs:
   add-version-tag:
-    # if: ${{ github.head_ref }} == ${{ env.CI_CHANGELOG_BUMP_BRANCH }} && ${{ github.event.pull_request.merged }} == true
-    if: ${{ env.CI_CHANGELOG_BUMP_BRANCH }} == "ci-update-changelog-next-release"
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -23,6 +21,8 @@ jobs:
           fetch-depth: 0
 
       - name: Create and push Debian version tag
+        # if: ${{ github.head_ref }} == ${{ env.CI_CHANGELOG_BUMP_BRANCH }} && ${{ github.event.pull_request.merged }} == true
+        if: ${{ env.CI_CHANGELOG_BUMP_BRANCH }} == "ci-update-changelog-next-release"
         run: |
           new_version="$(head -n1 debian/changelog | awk '{print $2}' | cut -d'-' -f1 | sed "s/(//g" | sed "s/)//g")"
           git tag "v${new_version}"

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -19,7 +19,7 @@ jobs:
         # if: github.head_ref == needs.get-ci-changelog-branch-name.outputs.should_run && github.event.pull_request.merged == true
         id: secret
         run: |
-          echo '::set-output name=should_run::false'
+          echo '::set-output name=should_run::true'
 
   add-version-tag:
     needs: [ get-should-run ]

--- a/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
+++ b/.github/workflows/tag-and-draft-release-on-changelog-pr-merge.yml
@@ -22,7 +22,7 @@ jobs:
           echo '::set-output name=should_run::false'
 
   add-version-tag:
-    needs: [ get-ci-changelog-branch-name ]
+    needs: [ get-should-run ]
     if: needs.get-should-run.outputs.should_run == 'true'
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Secrets and environment variables can't be used for job-level conditionals. Therefore, we create a pre-requisite job with an exposed output variable that _can_ be used.