### PR TITLE
Loop over available devices to create camera object

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,8 @@ Build-Depends:
  python3-gpiozero,
 # Required for building the docs (see rules file)
  python3-pip,
+# Required for autodetecting camera devices
+ v4l-utils,
 Standards-Version: 4.5.1
 Homepage: https://pi-top.com
 

--- a/pitop/camera/camera.py
+++ b/pitop/camera/camera.py
@@ -25,12 +25,13 @@ class Camera(Stateful, Recreatable):
     :type index: int
     :param index:
         ID of the video capturing device to open.
-        To open default camera using default backend just pass 0.
+        Passing `None` will cause the backend to autodetect the
+        available video capture devices and attempt to use them.
     """
     __VALID_FORMATS = ('opencv', 'pil')
 
     def __init__(self,
-                 index=0,
+                 index=None,
                  resolution=None,
                  camera_type=CameraTypes.USB_CAMERA,
                  path_to_images="",
@@ -99,8 +100,7 @@ class Camera(Stateful, Recreatable):
         self._format = format_value.lower()
 
     @classmethod
-    @type_check
-    def from_usb(cls, index: int = 0):
+    def from_usb(cls, index=None):
         """Alternative classmethod to create an instance of a :class:`Camera`
         object using a :data:`UsbCamera`"""
         return cls(camera_type=CameraTypes.USB_CAMERA, index=index)

--- a/pitop/camera/core/cameras/usb_camera.py
+++ b/pitop/camera/core/cameras/usb_camera.py
@@ -1,22 +1,34 @@
 from PIL import Image
+from os import listdir, system
 
 from PyV4L2Camera.camera import Camera as V4L2Camera
 from PyV4L2Camera.exceptions import CameraError as V4L2CameraError
 
 
 class UsbCamera:
-    def __init__(self, index: int = 0, resolution=None):
-        self.index = index
+    def __init__(self, index=None, resolution=None):
+        # if no index is provided, loop over available video devices
+        indexes = self.list_device_indexes() if index is None else [index]
         self.__camera = None
+        self.index = None
 
-        try:
-            if resolution is not None:
-                self.__camera = V4L2Camera(f"/dev/video{index}", resolution[0], resolution[1])
-            else:
-                self.__camera = V4L2Camera(f"/dev/video{index}")
+        for idx in indexes:
+            try:
+                self.__camera = self.create_camera_object(idx, resolution)
+                if self.__camera:
+                    self.index = idx
+                    break
+            except V4L2CameraError:
+                continue
 
-        except V4L2CameraError:
-            raise IOError(f"Error opening camera {index}. Make sure it's correctly connected via USB.") from None
+        if self.__camera is None:
+            raise IOError("Error opening camera. Make sure it's correctly connected via USB.") from None
+
+    def create_camera_object(self, index, resolution=None):
+        if resolution is not None:
+            return V4L2Camera(f"/dev/video{index}", resolution[0], resolution[1])
+        else:
+            return V4L2Camera(f"/dev/video{index}")
 
     def __del__(self):
         if hasattr(self.__camera, "close"):
@@ -31,3 +43,25 @@ class UsbCamera:
             'raw',
             'RGB'
         )
+
+    @staticmethod
+    def list_device_indexes():
+        indexes = []
+        device_names = [name for name in listdir("/dev") if "video" in name]
+
+        # Not all devices actually provide video
+        # eg: video1 can be a metadata device for video0
+        for device in device_names:
+            cmd = f"v4l2-ctl --list-formats --device /dev/{device} | grep -qE '[[0-9]]'"
+            try:
+                if system(cmd) != 0:
+                    continue
+                index = int(device[len("video"):])
+                # indexes > 10 are for bcm2835, not useful for us
+                if index < 10:
+                    indexes.append(index)
+            except Exception:
+                continue
+
+        indexes.sort()
+        return indexes

--- a/pitop/camera/core/cameras/usb_camera.py
+++ b/pitop/camera/core/cameras/usb_camera.py
@@ -3,6 +3,7 @@ from os import listdir, system
 
 from PyV4L2Camera.camera import Camera as V4L2Camera
 from PyV4L2Camera.exceptions import CameraError as V4L2CameraError
+from pitopcommon.command_runner import run_command
 
 
 class UsbCamera:
@@ -46,6 +47,13 @@ class UsbCamera:
 
     @staticmethod
     def list_device_indexes():
+        try:
+            run_command("dpkg -l v4l-utils", timeout=1, log_errors=False)
+        except Exception:
+            print("Warning: can't autodetect camera device indexes, using default value 0.")
+            print("Warning: Package v4l-utils is not installed. You can install it by running 'sudo apt install v4l-utils'.")
+            return [0]
+
         indexes = []
         device_names = [name for name in listdir("/dev") if "video" in name]
 

--- a/pitop/robotics/json/alex.json
+++ b/pitop/robotics/json/alex.json
@@ -4,7 +4,7 @@
     "module": "pitop.system.pitop",
     "components": {
         "camera": {
-            "index": 0,
+            "index": null,
             "resolution": [
                 640,
                 480


### PR DESCRIPTION
Closes https://github.com/pi-top/pi-top-Python-SDK/issues/268

- If no specific camera device index is provided, loop over available devices trying to create a camera object.
- The index is no longer stored in the camera state, unless it's explicitly set by the user.