### PR TITLE
ServoMotor: don't use setting on angle/speed properties

### DIFF
--- a/examples/pma/servo_motor.py
+++ b/examples/pma/servo_motor.py
@@ -1,19 +1,19 @@
-from pitop import ServoMotor, ServoMotorState
+from pitop import ServoMotor, ServoMotorSetting
 from time import sleep
 
 servo = ServoMotor("S0")
 
-# Scan back and forward across a 180 degree angle range in 10 degree hops using default servo speed
-for angle in range(90, -100, -10):
+# Scan back and forward across a 180 degree angle range in 30 degree hops using default servo speed
+for angle in range(90, -100, -30):
     print("Setting angle to", angle)
     servo.target_angle = angle
     sleep(0.5)
 
 # you can also set angle with a different speed than the default
-servo_settings = ServoMotorState()
+servo_settings = ServoMotorSetting()
 servo_settings.speed = 25
 
-for angle in range(-90, 100, 10):
+for angle in range(-90, 100, 30):
     print("Setting angle to", angle)
     servo_settings.angle = angle
     servo.setting = servo_settings
@@ -21,16 +21,18 @@ for angle in range(-90, 100, 10):
 
 sleep(1)
 
-# Scan back and forward by setting speed only and reading current angle
+# Scan back and forward displaying current angle and speed
 STOP_ANGLE = 80
-TARGET_SPEED = 25
+TARGET_SPEED = 40
 
-print("Setting target speed to ", -TARGET_SPEED)
+print("Sweeping using speed ", -TARGET_SPEED)
 servo.target_speed = -TARGET_SPEED
 
 current_state = servo.setting
 current_angle = current_state.angle
 
+# sweep using the already set servo speed
+servo.sweep()
 while current_angle > -STOP_ANGLE:
     current_state = servo.setting
     current_angle = current_state.angle
@@ -38,9 +40,10 @@ while current_angle > -STOP_ANGLE:
     print(f"current_angle: {current_angle} | current_speed: {current_speed}")
     sleep(0.05)
 
-print("Setting target speed to ", TARGET_SPEED)
-servo.target_speed = TARGET_SPEED
+print("Sweeping using speed ", TARGET_SPEED)
 
+# you can also sweep specifying the speed when calling the sweep method
+servo.sweep(speed=TARGET_SPEED)
 while current_angle < STOP_ANGLE:
     current_state = servo.setting
     current_angle = current_state.angle

--- a/pitop/pma/servo_motor.py
+++ b/pitop/pma/servo_motor.py
@@ -224,7 +224,7 @@ class ServoMotor(Stateful, Recreatable):
             raise ValueError(f"Speed value must be from {ServoHardwareSpecs.SPEED_RANGE} to {ServoHardwareSpecs.SPEED_RANGE} deg/s (inclusive)")
         self.__target_speed = speed
 
-    def sweep(self, speed):
+    def sweep(self, speed=None):
         """Moves the servo horn from the current position to one of the servo
         motor limits (maximum/minimum possible angle), moving at the specified
         speed. The speed value must be a number from -100.0 to 100.0 deg/s.
@@ -241,6 +241,7 @@ class ServoMotor(Stateful, Recreatable):
         :param speed:
             The target speed at which to move the servo horn, from -100 to 100 deg/s.
         """
+        speed = self.target_speed if speed is None else speed
         if not (-ServoHardwareSpecs.SPEED_RANGE <= speed <= ServoHardwareSpecs.SPEED_RANGE):
             raise ValueError(f"Speed value must be from {ServoHardwareSpecs.SPEED_RANGE} to {ServoHardwareSpecs.SPEED_RANGE} deg/s (inclusive)")
 


### PR DESCRIPTION
# Summary

Closes https://github.com/pi-top/pi-top-Python-SDK/issues/269

`ServoMotor` class: keep track of `angle` and `speed` as separate properties, not through the `setting` (former `state`) property

# Observations

Before releasing, we'll need to check the Further content against these changes.