### PR TITLE
Drop RPi.GPIO dependency

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -8,7 +8,6 @@ pyinotify python3-pyinotify
 pynput python3-pynput
 python_sonic python3-sonic
 pyv4l2camera python3-pyv4l2camera
-rpi.gpio python3-rpi.gpio
 scipy python3-scipy
 simple_pid python3-simple-pid
 smbus python3-smbus

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,8 +127,4 @@ autodoc_mock_imports = [
     'simple_pid',
     'smbus',
     'zmq',
-    # gpiozero dependencies
-    'RPi',
-    'RPIO',
-    'pigpio',
 ]

--- a/pitop/miniscreen/oled/core/device_controller.py
+++ b/pitop/miniscreen/oled/core/device_controller.py
@@ -17,7 +17,7 @@ try:
     import RPi.GPIO as GPIO
     # Suppress warning in Luma serial class
     GPIO.setwarnings(False)
-except RuntimeError:
+except (ImportError, RuntimeError):
     # This can only be run on Raspberry Pi
     # and is only required for reducing logging
     pass

--- a/pitop/protoplus/sensors.py
+++ b/pitop/protoplus/sensors.py
@@ -28,25 +28,23 @@ class DistanceSensor(gpiozero_DistanceSensor):
         contrast, the close method provides a means of ensuring that the object
         is shut down.
 
-        For example, if you have a DistanceSensor connected to port D4, but then wish
+        For example, if you have a buzzer connected to port D4, but then wish
         to attach an LED instead:
 
-            >>> from pitop.protoplus import DistanceSensor
-            >>> from pitop import LED
-            >>> distance = DistanceSensor("D4")
-            >>> distance.on()
-            >>> distance.off()
-            >>> distance.close()
+            >>> from pitop import Buzzer, LED
+            >>> bz = Buzzer("D4")
+            >>> bz.on()
+            >>> bz.off()
+            >>> bz.close()
             >>> led = LED("D4")
             >>> led.blink()
 
         :class:`Device` descendents can also be used as context managers using
         the :keyword:`with` statement. For example:
 
-            >>> from pitop.protoplus import DistanceSensor
-            >>> from pitop import LED
-            >>> with DistanceSensor("D4") as distance:
-            ...     distance.on()
+            >>> from pitop import Buzzer, LED
+            >>> with Buzzer("D4") as bz:
+            ...     bz.on()
             ...
             >>> with LED("D4") as led:
             ...     led.on()

--- a/pitop/protoplus/sensors.py
+++ b/pitop/protoplus/sensors.py
@@ -10,7 +10,7 @@ class DistanceSensor(gpiozero_DistanceSensor):
     """
 
     def __init__(self, trigger_gpio_pin=23, echo_gpio_pin=27):
-        gpiozero_DistanceSensor.__init__(self, trigger_gpio_pin, echo_gpio_pin)
+        gpiozero_DistanceSensor.__init__(self, echo_gpio_pin, trigger_gpio_pin)
 
     def close(self):
         """Shut down the device and release all associated resources. This

--- a/pitop/protoplus/sensors.py
+++ b/pitop/protoplus/sensors.py
@@ -10,7 +10,7 @@ class DistanceSensor(gpiozero_DistanceSensor):
     """
 
     def __init__(self, trigger_gpio_pin=23, echo_gpio_pin=27):
-        gpiozero_DistanceSensor.__init__(self, self.trigger_gpio_pin, self.echo_gpio_pin)
+        gpiozero_DistanceSensor.__init__(self, trigger_gpio_pin, echo_gpio_pin)
 
     def close(self):
         """Shut down the device and release all associated resources. This

--- a/pitop/protoplus/sensors.py
+++ b/pitop/protoplus/sensors.py
@@ -59,10 +59,6 @@ class DistanceSensor(gpiozero_DistanceSensor):
     def raw_distance(self):
         return self.distance
 
-    @property
-    def distance(self):
-        return self.distance
-
     def get_raw_distance(self):
         return self.distance
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ __requires__ = [
     # Proto+ #
     ##########
     "python-sonic",
-    "RPi.GPIO",
 
     #########
     # Pulse #

--- a/tests/test_miniscreen_buttons.py
+++ b/tests/test_miniscreen_buttons.py
@@ -7,8 +7,6 @@ modules["pyinotify"] = MagicMock()
 modules["pitopcommon.lock"] = MagicMock()
 modules["pitopcommon.logger"] = MagicMock()
 modules["pitopcommon.ptdm"] = MagicMock()
-modules["RPi"] = MagicMock()
-modules["RPi.GPIO"] = MagicMock()
 modules["luma.core.interface.serial"] = MagicMock()
 modules["luma.oled.device"] = MagicMock()
 

--- a/tests/test_miniscreen_oled.py
+++ b/tests/test_miniscreen_oled.py
@@ -11,8 +11,6 @@ modules["pitopcommon.lock"] = MagicMock()
 modules["pitopcommon.ptdm"] = MagicMock()
 modules["pitopcommon.logger"] = MagicMock()
 modules["numpy"] = MagicMock()
-modules["RPi"] = MagicMock()
-modules["RPi.GPIO"] = MagicMock()
 modules["luma.core.interface.serial"] = MagicMock()
 modules["luma.oled.device"] = MagicMock()
 


### PR DESCRIPTION
Proto+ now uses `gpiozero`'s `DistanceSensor`.
RPi.GPIO is still used to suppress warnings in Luma, but with handling of failed import, this becomes a soft dependency.

Closes #266 