### PR TITLE
Use pre-commit for RST format check

### DIFF
--- a/.github/workflows/test-and-build-on-all-commits.yml
+++ b/.github/workflows/test-and-build-on-all-commits.yml
@@ -1,10 +1,9 @@
 name: Test and Build Packages on All Commits
-# TODO: provide latest commit to 'master' as pre-release GitHub Release
 
-# Don't run on branches intended for CI modifications
 on:
   push:
     branches-ignore:
+      # Don't run on branches intended for CI modifications
       - "ci-test-*"
 
 jobs:
@@ -21,6 +20,7 @@ jobs:
         uses: pre-commit/action@v2.0.0
 
   python-test-coverage:
+    needs: pre-commit-checks
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Python
@@ -65,28 +65,8 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-  test-readme-render:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2.2.0
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install readme-renderer
-
-      - name: Test README can be rendered
-        run: |
-          python -m readme_renderer README.rst -o /dev/null
-
   build-debian-packages:
-    needs: [ pre-commit-checks, python-test-coverage, test-readme-render ]
+    needs: python-test-coverage
     runs-on: ubuntu-20.04
     steps:
       - name: GitHub Environment Variables Action

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,12 @@ repos:
     hooks:
     - id: docformatter
 
+-   repo: https://github.com/myint/rstcheck
+    rev: '3f92957478422df87bd730abde66f089cc1ee19b'
+    hooks:
+    - id: rstcheck
+      args: ["--recursive"]
+
 -   repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v1.5.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,22 @@ repos:
     rev: '3f92957478422df87bd730abde66f089cc1ee19b'
     hooks:
     - id: rstcheck
-      args: ["--recursive"]
+      args: [
+        "--report", "warning",
+        "--ignore-roles", "class",
+        "--ignore-directives", "autoclass,automodule",
+      ]
 
 -   repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v1.5.4
     hooks:
     - id: autopep8
       name: autopep8 - all checks, no tests
-      args: ["-i", "--max-line-length=150", "--exclude", "tests/*"]
+      args: [
+        "-i",
+        "--max-line-length=150",
+        "--exclude", "tests/*"
+      ]
 
 -   repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v1.5.4
@@ -34,7 +42,11 @@ repos:
     - id: autopep8
       # Default: E226,E24,W50,W690
       name: autopep8 - ignore import checks, include tests
-      args: ["-i", "--max-line-length=150", "--ignore", "E226,E24,W50,W690,E402"]
+      args: [
+        "-i",
+        "--max-line-length=150",
+        "--ignore", "E226,E24,W50,W690,E402"
+      ]
 
 -   repo: https://gitlab.com/PyCQA/flake8
     rev: 3.8.4

--- a/docs/cli_tools.rst
+++ b/docs/cli_tools.rst
@@ -232,7 +232,7 @@ peripherals
 
 Example:
 
-.. code-block:: bash
+..
 
     pi@pi-top:~ $ pi-top devices
     HUB ===================================================
@@ -247,8 +247,6 @@ Example:
     [   ] pi-topSPEAKER (v1) - Mono
     [   ] pi-topSPEAKER (v2)
 
-.. code-block:: bash
-
     pi@pi-top:~ $ pt devices peripherals
     [ ✓ ] pi-top [4] Expansion Plate (v21.5)
     [   ] pi-top Touchscreen
@@ -258,8 +256,6 @@ Example:
     [   ] pi-topSPEAKER (v1) - Right channel
     [   ] pi-topSPEAKER (v1) - Mono
     [   ] pi-topSPEAKER (v2)
-
-.. code-block:: bash
 
     pi@pi-top:~ $ pt devices hub --name-only
     pi-top [4]


### PR DESCRIPTION
With this PR, we will have all of the repo-specific checks handled at the `pre-commit` level.
Test coverage report now waits for pre-commit checks. Builds still wait on test coverage reports.

`--ignore-roles class --ignore-directives autoclass,automodule` seems to be needed to prevent this from showing:
```
docs/api_system_devices.rst:25: (ERROR/3) Unknown interpreted text role "class".
docs/api_pitop_device.rst:29: (ERROR/3) Unknown directive type "autoclass".
docs/api_pitop_peripheral_devices.rst:22: (ERROR/3) Unknown directive type "autoclass".
docs/api_pma_components.rst:29: (ERROR/3) Unknown directive type "autoclass".
```
However, it might be better to understand why this is happening and, preferably, address it directly.

Actual code changes are required for `rstcheck` to pass.