### PR TITLE
Migrate to pre-commit.ci

### DIFF
--- a/.github/workflows/test-and-build-on-all-commits.yml
+++ b/.github/workflows/test-and-build-on-all-commits.yml
@@ -7,20 +7,6 @@ on:
       - "ci-test-*"
 
 jobs:
-  pre-commit-checks:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2.2.0
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Run all pre-commit checks against all files
-        uses: pre-commit/action@v2.0.0
-
   python-test-coverage:
     needs: pre-commit-checks
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-and-build-on-all-commits.yml
+++ b/.github/workflows/test-and-build-on-all-commits.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   python-test-coverage:
-    needs: pre-commit-checks
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
Repo is now registered with https://pre-commit.ci/, so we can drop `pre-commit` checks.