### PR TITLE
Change .detect to direct call of class instance

### DIFF
--- a/examples/camera/camera_coloured_ball_detect.py
+++ b/examples/camera/camera_coloured_ball_detect.py
@@ -5,7 +5,7 @@ import cv2
 
 
 def process_frame(frame):
-    detected_balls = ball_detector.detect(frame, color=["red", "green", "blue"])
+    detected_balls = ball_detector(frame, color=["red", "green", "blue"])
 
     red_ball = detected_balls.red
     if red_ball.found:

--- a/pitop/processing/algorithms/ball_detect.py
+++ b/pitop/processing/algorithms/ball_detect.py
@@ -156,7 +156,7 @@ class BallDetector:
             self._fps = FPS().start()
             atexit.register(self.__print_fps)
 
-    def detect(self, frame, color: Union[str, list] = "red"):
+    def __call__(self, frame, color: Union[str, list] = "red"):
         def parse_colors(color_arg):
             colors = []
             if type(color_arg) == str:

--- a/tests/test_ball_detector.py
+++ b/tests/test_ball_detector.py
@@ -56,7 +56,7 @@ class TestBallDetector(TestCase):
         red_ball_center = center_reposition(red_ball_center, cv_frame)
         red_ball_angle = get_object_target_lock_control_angle(red_ball_center, cv_frame)
 
-        balls = ball_detector.detect(cv_frame, color="red")
+        balls = ball_detector(cv_frame, color="red")
 
         red_ball = balls.red
 
@@ -111,7 +111,7 @@ class TestBallDetector(TestCase):
 
         pil_frame = convert(cv_frame, "PIL")
 
-        balls = ball_detector.detect(pil_frame, color=["red", "green", "blue"])
+        balls = ball_detector(pil_frame, color=["red", "green", "blue"])
 
         red_ball = balls.red
         green_ball = balls.green
@@ -151,7 +151,7 @@ class TestBallDetector(TestCase):
         # Check that a second false detection attempt still returns a longer deque
         cv_frame = self._blank_cv_frame.copy()
         pil_frame = convert(cv_frame, "PIL")
-        balls = ball_detector.detect(pil_frame, color=["red", "green", "blue"])
+        balls = ball_detector(pil_frame, color=["red", "green", "blue"])
 
         red_ball = balls.red
         green_ball = balls.green
@@ -166,7 +166,7 @@ class TestBallDetector(TestCase):
         ball_detector = BallDetector()
         cv_frame = self._blank_cv_frame.copy()
         pil_frame = convert(cv_frame, "PIL")
-        balls = ball_detector.detect(pil_frame, color=["red", "green", "blue"])
+        balls = ball_detector(pil_frame, color=["red", "green", "blue"])
 
         red_ball = balls.red
         green_ball = balls.green
@@ -202,7 +202,7 @@ class TestBallDetector(TestCase):
         self.assertIsInstance(balls.robot_view, np.ndarray)
 
         # Check that another detection attempt returns a longer deque
-        balls = ball_detector.detect(pil_frame, color=["red", "green", "blue"])
+        balls = ball_detector(pil_frame, color=["red", "green", "blue"])
 
         red_ball = balls.red
         green_ball = balls.green
@@ -222,7 +222,7 @@ class TestBallDetector(TestCase):
         red_ball_center = (self._width // 2, self._height)
         cv2.circle(cv_frame, red_ball_center, ball_radius, color['red'], -1)
 
-        balls = ball_detector.detect(cv_frame, color="red")
+        balls = ball_detector(cv_frame, color="red")
         red_ball = balls.red
 
         # Check found boolean
@@ -237,7 +237,7 @@ class TestBallDetector(TestCase):
         red_ball_center = (self._width // 2, self._height // 2)
         cv2.circle(cv_frame, red_ball_center, ball_radius, color['red'], -1)
 
-        balls = ball_detector.detect(cv_frame, color="red")
+        balls = ball_detector(cv_frame, color="red")
         red_ball = balls.red
 
         self.assertFalse(red_ball.found)
@@ -249,9 +249,9 @@ class TestBallDetector(TestCase):
         ball_detector = BallDetector()
         cv_frame = self._blank_cv_frame.copy()
         pil_frame = convert(cv_frame, "PIL")
-        self.assertRaises(ValueError, ball_detector.detect, pil_frame, color="rainbow")
-        self.assertRaises(ValueError, ball_detector.detect, pil_frame, color=["rainbow", "red"])
-        self.assertRaises(ValueError, ball_detector.detect, pil_frame, color=[0, 1])
+        self.assertRaises(ValueError, ball_detector, pil_frame, color="rainbow")
+        self.assertRaises(ValueError, ball_detector, pil_frame, color=["rainbow", "red"])
+        self.assertRaises(ValueError, ball_detector, pil_frame, color=[0, 1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Replace `.detect()` function in BallDetector with `__call__`

`ball_detector.detect` is long and unnecessary, just calling the ball_detector directly is more in line with how other libraries work

`detected_balls = ball_detector.detect(frame, color=["red", "green", "blue"])`
becomes:
`detected_balls = ball_detector(frame, color=["red", "green", "blue"])`