### PR TITLE
Use imutils to ensure contour is grabbed regardless of cv version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,7 @@ autodoc_mock_imports = [
     'cv2',
     'numpy',
     'imageio',
+    'imutils',
     'luma',
     'luma.oled',
     'luma.core',

--- a/pitop/processing/core/vision_functions.py
+++ b/pitop/processing/core/vision_functions.py
@@ -1,4 +1,5 @@
 from matplotlib import colors
+from imutils import grab_contours
 
 
 def import_opencv():
@@ -27,7 +28,7 @@ def color_mask(frame, hsv_lower, hsv_upper):
 def find_largest_contour(frame):
     cv2 = import_opencv()
     # Find the contours of the frame. RETR_EXTERNAL: retrieves only the extreme outer contours
-    image, contours, hierarchy = cv2.findContours(frame, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    contours = grab_contours(cv2.findContours(frame, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE))
 
     # Find the biggest contour (if detected)
     if len(contours) > 0:


### PR DESCRIPTION
When OpenCV is installed via pip:

```
Exception in thread Thread-6:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/home/pi/pi-top-Python-SDK/pitop/camera/camera.py", line 255, in __process_camera_output
    self.on_frame(self.__get_processed_current_frame())
  File "/home/pi/further/608ab650d0b357001b0f3945/line_follow.py", line 14, in drive_based_on_frame
    processed_frame = process_frame_for_line(frame)
  File "/home/pi/pi-top-Python-SDK/pitop/processing/algorithms/line_detect.py", line 40, in process_frame_for_line
    line_contour = find_largest_contour(image_mask)
  File "/home/pi/pi-top-Python-SDK/pitop/processing/utils/vision_functions.py", line 27, in find_largest_contour
    image, contours, hierarchy = cv2.findContours(frame, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
ValueError: not enough values to unpack (expected 3, got 2)
```