### PR TITLE
Remove double Pitop __init__ in AlexRobot

### DIFF
--- a/pitop/robotics/configurations.py
+++ b/pitop/robotics/configurations.py
@@ -20,9 +20,8 @@ alex_config = __load_json("alex.json")
 bobbie_config = __load_json("bobbie.json")
 
 
-class AlexRobot(Pitop):
+class AlexRobot:
     def __init__(self, *args, **kwargs):
-        super(AlexRobot, self).__init__()
         print("AlexRobot class is deprecated. Please use Pitop.from_config(alex_config)")
 
     def __new__(cls, *args, **kwargs):


### PR DESCRIPTION
```
from pitop import AlexRobot
alex = AlexRobot()
```
This hangs presumably because the Miniscreen is already taken from the `Pitop.from_config` command already run 