### PR TITLE
Add optional properties for autocomplete functionality when doing robotics

### DIFF
--- a/pitop/system/pitop.py
+++ b/pitop/system/pitop.py
@@ -4,6 +4,8 @@ from pitop.core.mixins import (
     SupportsBattery,
     SupportsMiniscreen,
 )
+from typing import Optional
+from pitop import DriveController, Camera, PanTiltController
 
 
 class Pitop(SupportsMiniscreen, SupportsBattery, Componentable, metaclass=Singleton):
@@ -19,7 +21,8 @@ class Pitop(SupportsMiniscreen, SupportsBattery, Componentable, metaclass=Single
     class in 2 different files, they will share the internal state.
 
     *property* miniscreen
-        If using a pi-top [4], this property returns a :class:`pitop.miniscreen.Miniscreen` object, to interact with the device's Miniscreen.
+        If using a pi-top [4], this property returns a :class:`pitop.miniscreen.Miniscreen` object, to interact with
+        the device's Miniscreen.
 
 
     *property* oled
@@ -27,8 +30,30 @@ class Pitop(SupportsMiniscreen, SupportsBattery, Componentable, metaclass=Single
 
 
     *property* battery
-        If using a pi-top with a battery, this property returns a :class:`pitop.battery.Battery` object, to interact with the device's battery.
+        If using a pi-top with a battery, this property returns a :class:`pitop.battery.Battery` object, to interact
+        with the device's battery.
+
+
+    *property* drive
+        Convenience property to provide autocomplete and introspection functionality in common IDEs.
+        If you have not used the `add_component` or `from_config` methods to add a `DriveController` object and you try
+        to run your program with this property, an exception will be raised.
+
+
+    *property* camera
+        Convenience property to provide autocomplete and introspection functionality in common IDEs.
+        If you have not used the `add_component` or `from_config` methods to add a `Camera` object and you try to run
+        your program with this property, an exception will be raised.
+
+
+    *property* pan_tilt
+        Convenience property to provide autocomplete and introspection functionality in common IDEs.
+        If you have not used the `add_component` or `from_config` methods to add a `PanTiltController` object and you
+        try to run your program with this property, an exception will be raised.
     """
+    drive: Optional[DriveController]
+    camera: Optional[Camera]
+    pan_tilt: Optional[PanTiltController]
 
     def __init__(self):
         SupportsMiniscreen.__init__(self)


### PR DESCRIPTION
Putting this here for discussion purposes mainly, we got [this forum](https://forum.pi-top.com/t/nothing-happens-when-calibrating-motors-on-alex/844/6?u=duwudi) question recently and it reminded me of the discussion we had before - this PR implements @angusjfw's suggestion from that.

These are the limitations with the approach I can see (there are probably more):

1. There are a lot more components that can be added to a Pitop object dynamically and this will grow with time (e.g. PMA, NavigationController etc) - this currently only covers the common properties for robotics. Could we add these Optional properties based on a master list we keep somewhere that defines all `Recreatable` components?
2. People might incorrectly assume that these properties are available before they've used the `add_component` or `from_config` methods - resulting in errors and confusion. I'm not sure if we can catch this at runtime and provide an explanation of what to do but that would certainly help. My hope is that they will follow the examples properly and in the cases where they don't, will read the docs and see how to do it properly.

