### PR TITLE
Change all PMA components to use RPi.GPIO pin factory

### DIFF
--- a/pitop/pma/button.py
+++ b/pitop/pma/button.py
@@ -1,6 +1,4 @@
 from gpiozero import Button as gpiozero_Button
-from gpiozero.pins.native import NativeFactory
-
 from pitop.core.mixins import (
     Stateful,
     Recreatable,
@@ -22,7 +20,7 @@ class Button(Stateful, Recreatable, gpiozero_Button):
 
         Stateful.__init__(self)
         Recreatable.__init__(self, {"port_name": port_name, "name": self.name})
-        gpiozero_Button.__init__(self, get_pin_for_port(self._pma_port), pin_factory=NativeFactory())
+        gpiozero_Button.__init__(self, get_pin_for_port(self._pma_port))
 
     @property
     def own_state(self):

--- a/pitop/pma/buzzer.py
+++ b/pitop/pma/buzzer.py
@@ -1,6 +1,4 @@
 from gpiozero import Buzzer as gpiozero_Buzzer
-from gpiozero.pins.native import NativeFactory
-
 from pitop.core.mixins import (
     Stateful,
     Recreatable,
@@ -21,7 +19,7 @@ class Buzzer(Stateful, Recreatable, gpiozero_Buzzer):
 
         Stateful.__init__(self)
         Recreatable.__init__(self, {"port_name": port_name, "name": self.name})
-        gpiozero_Buzzer.__init__(self, get_pin_for_port(self._pma_port), pin_factory=NativeFactory())
+        gpiozero_Buzzer.__init__(self, get_pin_for_port(self._pma_port))
 
     @property
     def own_state(self):

--- a/pitop/pma/led.py
+++ b/pitop/pma/led.py
@@ -1,6 +1,4 @@
 from gpiozero import LED as gpiozero_LED
-from gpiozero.pins.native import NativeFactory
-
 from pitop.core.mixins import (
     Stateful,
     Recreatable,
@@ -22,7 +20,7 @@ class LED(Stateful, Recreatable, gpiozero_LED):
 
         Stateful.__init__(self)
         Recreatable.__init__(self, {"port_name": port_name, "name": self.name})
-        gpiozero_LED.__init__(self, get_pin_for_port(self._pma_port), pin_factory=NativeFactory())
+        gpiozero_LED.__init__(self, get_pin_for_port(self._pma_port))
 
     @property
     def own_state(self):

--- a/pitop/pma/ultrasonic_sensor.py
+++ b/pitop/pma/ultrasonic_sensor.py
@@ -1,4 +1,3 @@
-from gpiozero.pins.native import NativeFactory
 from gpiozero import SmoothedInputDevice
 from threading import Event, Lock
 
@@ -38,7 +37,6 @@ class UltrasonicSensor(Stateful, Recreatable, SmoothedInputDevice):
                                      sample_wait=0.06,
                                      partial=partial,
                                      ignore=frozenset({None}),
-                                     pin_factory=NativeFactory(),
                                      )
 
         try:
@@ -114,22 +112,6 @@ class UltrasonicSensor(Stateful, Recreatable, SmoothedInputDevice):
         try:
             super(UltrasonicSensor, self).close()
         except RuntimeError:
-            # Currently, if used with OLED, this will raise the following exception:
-            #
-            # Exception ignored in: <function GPIOBase.__del__ at 0xb5041660>
-            # Traceback (most recent call last):
-            #   File "/usr/lib/python3/dist-packages/gpiozero/devices.py", line 151, in __del__
-            #   File "/usr/lib/python3/dist-packages/pitop/pma/ultrasonic_sensor.py", line 98, in close
-            #   File "/usr/lib/python3/dist-packages/gpiozero/input_devices.py", line 299, in close
-            #   File "/usr/lib/python3/dist-packages/gpiozero/devices.py", line 540, in close
-            #   File "/usr/lib/python3/dist-packages/gpiozero/pins/native.py", line 397, in close
-            #   File "/usr/lib/python3/dist-packages/gpiozero/pins/__init__.py", line 420, in <lambda>
-            #   File "/usr/lib/python3/dist-packages/gpiozero/pins/native.py", line 468, in _set_edges
-            # RuntimeError: could not find io module state (interpreter shutdown?)
-
-            # This can be removed when no other part of the SDK is using RPi.GPIO
-            # TODO: evaluate removing Luma dependency, in favour of direct use of SPIDEV
-            # to ensure that RPi.GPIO and gpiozero are not used together
             PTLogger.debug(f"Ultrasonic Sensor on port {self._pma_port} - "
                            "there was an error in closing the port!")
 


### PR DESCRIPTION
Using the NativeFactory (as opposed to RPi.GPIO factory) in GPIOZero causes issues with cleanup of components:

```
pi@pi-top:~ $ python3 -c "from pitop import Button;Button('D1')" # instantiate a button to trigger the problem
pi@pi-top:~ $ python3 -c "from pitop import LED;l = LED('D1')" # with variable to produce error
Exception ignored in: <function GPIOBase.__del__ at 0xb5781738>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/gpiozero/devices.py", line 151, in __del__
  File "/home/pi/pi-top-Python-SDK/pitop/pma/led.py", line 72, in close
  File "/usr/lib/python3/dist-packages/gpiozero/output_devices.py", line 225, in close
  File "/usr/lib/python3/dist-packages/gpiozero/mixins.py", line 110, in close
  File "/usr/lib/python3/dist-packages/gpiozero/devices.py", line 540, in close
  File "/usr/lib/python3/dist-packages/gpiozero/pins/native.py", line 397, in close
  File "/usr/lib/python3/dist-packages/gpiozero/pins/__init__.py", line 420, in <lambda>
  File "/usr/lib/python3/dist-packages/gpiozero/pins/native.py", line 468, in _set_edges
  File "/usr/lib/python3.7/_bootlocale.py", line 35, in getpreferredencoding
AttributeError: 'NoneType' object has no attribute 'utf8_mode'
pi@pi-top:~ $ python3 -c "from pitop import LED;LED('D1')" # no variable no error
```

The reason we used NativeFactory was because of a clash with luma.core, which also uses GPIOZero - resulting in the following error upon program exit when using PMA components with the miniscreen:

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3/dist-packages/gpiozero/mixins.py", line 551, in fill
    value = self.parent._read()
  File "/usr/lib/python3/dist-packages/pitop/pma/ultrasonic_sensor.py", line 209, in _read
    if self.pin.state:
  File "/usr/lib/python3/dist-packages/gpiozero/pins/__init__.py", line 304, in <lambda>
    lambda self: self._get_state(),
  File "/usr/lib/python3/dist-packages/gpiozero/pins/rpigpio.py", line 167, in _get_state
    return GPIO.input(self.number)
RuntimeError: Please set pin numbering mode using GPIO.setmode(GPIO.BOARD) or GPIO.setmode(GPIO.BCM)
```

However, this has recently been resolved [here](https://github.com/rm-hull/luma.core/pull/237), luma.core now only cleans up the GPIOs it is actually using instead of all of them.

The OS is currently using **version 2.2.0** of luma.core, so we need to **update it to 2.3.1** before this PR is merged.
