### PR TITLE
Make tilt roll head controller name and attributes less verbose

### DIFF
--- a/examples/recipes/robot_head_rotation_tracker.py
+++ b/examples/recipes/robot_head_rotation_tracker.py
@@ -14,19 +14,19 @@ def track_face(frame):
 
     if face.found:
         face_angle = face.angle
-        robot.tilt_roll.track_head_angle(face_angle)
+        robot.head.track_head_angle(face_angle)
         print(f"Face angle: {face.angle}")
     else:
-        robot.tilt_roll.roll_servo.sweep(speed=0)
+        robot.head.roll.sweep(speed=0)
         print("Cannot find face!")
 
 
 robot = Pitop()
 
 robot.add_component(TiltRollHeadController(servo_roll_port="S0", servo_tilt_port="S3"))
-robot.tilt_roll.calibrate()
-robot.tilt_roll.tilt_servo.target_angle = 70
-robot.tilt_roll.roll_servo.target_angle = 0
+robot.head.calibrate()
+robot.head.tilt.target_angle = 70
+robot.head.roll.target_angle = 0
 
 robot.add_component(Camera(resolution=(640, 480), flip_top_bottom=True))
 

--- a/pitop/robotics/tilt_roll_head_controller.py
+++ b/pitop/robotics/tilt_roll_head_controller.py
@@ -12,7 +12,7 @@ class TiltRollHeadController(Stateful, Recreatable):
     _roll_servo = None
     _tilt_servo = None
 
-    def __init__(self, servo_roll_port="S0", servo_tilt_port="S3", name="tilt_roll"):
+    def __init__(self, servo_roll_port="S0", servo_tilt_port="S3", name="head"):
         self.name = name
         self._roll_servo = ServoMotor(servo_roll_port)
         self._tilt_servo = ServoMotor(servo_tilt_port)
@@ -28,27 +28,27 @@ class TiltRollHeadController(Stateful, Recreatable):
         Recreatable.__init__(self, config_dict={'servo_roll_port': servo_roll_port, 'servo_tilt_port': servo_tilt_port, 'name': name})
 
     @property
-    def roll_servo(self):
+    def roll(self):
         return self._roll_servo
 
     @property
-    def tilt_servo(self):
+    def tilt(self):
         return self._tilt_servo
 
     def stop(self):
-        self.tilt_servo.sweep(speed=0)
-        self.roll_servo.sweep(speed=0)
+        self.tilt.sweep(speed=0)
+        self.roll.sweep(speed=0)
 
     def track_head_angle(self, angle, flipped=True):
         if not flipped:
             angle = -angle
-        current_angle = self.roll_servo.current_angle
+        current_angle = self.roll.current_angle
         state = current_angle - angle
         if abs(state) < 1.0:
-            self.roll_servo.sweep(speed=0)
+            self.roll.sweep(speed=0)
         else:
             servo_speed = self._head_roll_pid(state)
-            self.roll_servo.sweep(speed=servo_speed)
+            self.roll.sweep(speed=servo_speed)
 
     def calibrate(self, save=True, reset=False):
         """Calibrates the assembly to work in optimal conditions.
@@ -67,6 +67,6 @@ class TiltRollHeadController(Stateful, Recreatable):
         calibration_object = TwoServoAssemblyCalibrator(
             filename=self.CALIBRATION_FILE_NAME,
             section_name="TILT_ROLL",
-            servo_lookup_dict={"roll_zero_point": self.roll_servo, "tilt_zero_point": self.tilt_servo}
+            servo_lookup_dict={"roll_zero_point": self.roll, "tilt_zero_point": self.tilt}
         )
         calibration_object.calibrate(save, reset)


### PR DESCRIPTION
`tilt_roll` -> `head` 
`tilt_servo` -> `tilt` 
`roll_servo` -> `roll`

`robot.head.tilt` more intuitive than `robot.tilt_roll.tilt_servo`