### PR TITLE
Add scheduler and put on_frame() call into it's own thread

### DIFF
--- a/pitop/camera/camera.py
+++ b/pitop/camera/camera.py
@@ -15,6 +15,9 @@ from pitop.pma.common import type_check
 from enum import Enum
 from inspect import signature
 from threading import Thread, Event
+import time
+import sched
+
 
 
 class Camera(Stateful, Recreatable):
@@ -72,7 +75,9 @@ class Camera(Stateful, Recreatable):
         self.__continue_processing = True
         self.__frame_handler = FrameHandler()
         self.__new_frame_event = Event()
-        self.__process_image_thread = Thread(target=self.__process_camera_output, daemon=True)
+        self._camera_fps = 30
+        self.__on_frame_thread = Thread()
+        self.__process_image_thread = Thread(target=self.__processes_camera_scheduler, daemon=True)
         self.__process_image_thread.start()
 
         self.name = name
@@ -268,18 +273,36 @@ class Camera(Stateful, Recreatable):
 
         return image
 
-    def __process_camera_output(self):
-        while self.__camera and self.__continue_processing is True:
-            self.__frame_handler.frame = self.__camera.get_frame()
-            self.__new_frame_event.set()
+    def __processes_camera_scheduler(self):
+        s = sched.scheduler(time.time, time.sleep)
+        s.enter(0, 1, self.__process_camera_output, (s, ))
+        s.run()
 
-            if callable(self.on_frame):
-                self.on_frame(self.__get_processed_current_frame())
+    def __process_camera_output(self, s):
+        if not self.__camera or not self.__continue_processing:
+            return
 
-            try:
-                self.__frame_handler.process()
-            except Exception as e:
-                print(f"Error in camera frame handler: {e}")
+        frame_grab_time = time.time()
+
+        self.__frame_handler.frame = self.__camera.get_frame()
+        self.__new_frame_event.set()
+
+        if callable(self.on_frame) and not self.__on_frame_thread.is_alive():
+            self.__on_frame_thread = Thread(target=self.on_frame,
+                                            daemon=True,
+                                            args=(self.__get_processed_current_frame(),)
+                                            )
+            self.__on_frame_thread.start()
+
+        try:
+            self.__frame_handler.process()
+        except Exception as e:
+            print(f"Error in camera frame handler: {e}")
+
+        time_since_frame = time.time() - frame_grab_time
+        time_to_next_frame = max(0.0, 1 / self._camera_fps - time_since_frame)
+
+        s.enter(time_to_next_frame, 1, self.__process_camera_output, (s,))
 
     def current_frame(self, format=None):
         """Returns the latest frame captured by the camera. This method is non-


### PR DESCRIPTION
I was hoping this would fix #367. It didn't but I think the changes are worthwhile regardless. Changes:


### 1. Frame retrieval is no longer in a `while True` loop. 

- It's a scheduler instead
- The behaviour of the scheduler is almost identical to a while True loop since the `time_to_next_frame` is zero around 95% of the time (meaning it acts exactly like a while true with no delay). 
- However, for the 5% of times, and also if the user is requesting a lower resolution, a small delay will be placed in the thread which frees up time otherwise spent waiting on the USB camera device. 
- We can see from 8330fa1acf5d2c8f04076d3e49a4b0193ca4cee2 that small delays are a good thing and can benefit other parts of the system.

### 2. Calling `self.on_frame` is done by a separate thread

- This prevents the camera loop from being locked up by the user's on_frame callback function
- This means the next USB camera call is not blocked and can start being retrieved ready for when it's needed. 
- In the worst case, the thread running the user's callback function finishes just after the new frame is ready. This results in it being missed and the loop goes onto get another USB camera frame. This worst case is exactly the current behaviour of the SDK. - In the best case, the user processing is shorter than the time it takes to grab a new frame and as soon as it's ready it calls their callback function again - the time saved is always going to be greater or equal to the current blocking case.

For change 1, I'm not sure if it's worthwhile implementing over a `while True` loop, but change 2 is definitely an improvement.

The reason this PR doesn't fix #367 is the same reason why change 1 might not be worth implementing - they are essentially doing the same thing. This is because the `self.__frame_handler.frame = self.__camera.get_frame()` is the bottleneck (time is very close to 1/FPS)