### PR TITLE
Only main thread can join miniscreen background thread

### DIFF
--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -441,6 +441,7 @@ class OLED:
         :param bool loop: Set whether the image animation should start again when it
             has finished
         """
+        self.stop_animated_image()
         self.__kill_thread = False
         if background is True:
             self.__auto_play_thread = Thread(target=self.__auto_play, args=(image, loop))

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -660,6 +660,7 @@ class OLED:
         self.__file_monitor_thread.start()
 
     def __cleanup(self):
+        self.stop_animated_image()
         if self.__file_monitor_thread is not None and self.__file_monitor_thread.is_alive():
             self.__file_monitor_thread.join(0)
 

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -23,7 +23,11 @@ from pyinotify import (
     ProcessEvent,
     WatchManager,
 )
-from threading import Thread
+from threading import (
+    Thread,
+    current_thread,
+    main_thread,
+)
 from time import sleep
 
 
@@ -439,8 +443,7 @@ class OLED:
         """
         self.__kill_thread = False
         if background is True:
-            self.__auto_play_thread = Thread(
-                target=self.__auto_play, args=(image, loop))
+            self.__auto_play_thread = Thread(target=self.__auto_play, args=(image, loop))
             self.__auto_play_thread.start()
         else:
             self.__auto_play(image, loop)
@@ -448,7 +451,11 @@ class OLED:
     def stop_animated_image(self):
         """Stop background animation started using `start()`, if currently
         running."""
-        if self.__auto_play_thread is not None:
+        if current_thread() is not main_thread():
+            # thread that runs an animation in the background can't "join" itself
+            return
+
+        if self.__auto_play_thread is not None and self.__auto_play_thread.is_alive():
             self.__kill_thread = True
             self.__auto_play_thread.join()
 


### PR DESCRIPTION
Miniscreen's `play_animated_image` method errors if parameter `background=True`:

```
>>> miniscreen.play_animated_image_file("/usr/lib/python3/dist-packages/pitop/miniscreen/images/rocket.gif", background=True)
>>> Exception in thread Thread-9:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 597, in __auto_play
    self.display_image(frame)
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 284, in display_image
    invert=invert,
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 402, in __display
    self.stop_animated_image()
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 453, in stop_animated_image
    self.__auto_play_thread.join(0)
  File "/usr/lib/python3.7/threading.py", line 1029, in join
    raise RuntimeError("cannot join current thread")
RuntimeError: cannot join current thread
```

This is because every time an image is displayed by the method, the class makes sure to stop any thread that runs in the background. When the new thread that runs the animated file in the background tries to do this, it tries to join itself to the main process, and fails.

The changes included in this PR will make sure that only the main thread is able to stop spawned threads.