### PR TITLE
Add keyword arg to select font to miniscreen display text methods

### DIFF
--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -288,7 +288,7 @@ class OLED:
             invert=invert,
         )
 
-    def display_text(self, text, xy=None, font_size=None, invert=False):
+    def display_text(self, text, xy=None, font_size=None, font=None, invert=False):
         """Renders a single line of text to the screen at a given position and
         size.
 
@@ -301,6 +301,8 @@ class OLED:
             the screen.
         :param int font_size: The font size in pixels. If not provided or passed as
             `None`, the default font size will be used
+        :param string font: A filename or path of a TrueType or OpenType font.
+            If not provided or passed as `None`, the default font will be used
         :param bool invert: Set to True to flip the on/off state of each pixel in the image
         """
         if xy is None:
@@ -308,6 +310,9 @@ class OLED:
 
         if font_size is None:
             font_size = 30
+
+        if font is None:
+            font = self.__font_path()
 
         # Create empty image
         image = self.__empty_image
@@ -317,7 +322,7 @@ class OLED:
             xy,
             str(text),
             font=ImageFont.truetype(
-                self.__font_path(),
+                font,
                 size=font_size
             ),
             fill=1,
@@ -328,7 +333,7 @@ class OLED:
         # Display image
         self.display_image(image, invert=invert)
 
-    def display_multiline_text(self, text, xy=None, font_size=None):
+    def display_multiline_text(self, text, xy=None, font_size=None, font=None):
         """Renders multi-lined text to the screen at a given position and size.
         Text that is too long for the screen will automatically wrap to the
         next line.
@@ -342,6 +347,8 @@ class OLED:
             the screen.
         :param int font_size: The font size in pixels. If not provided or passed as
             `None`, the default font size will be used
+        :param string font: A filename or path of a TrueType or OpenType font.
+            If not provided or passed as `None`, the default font will be used
         """
         if xy is None:
             xy = self.top_left
@@ -349,12 +356,15 @@ class OLED:
         if font_size is None:
             font_size = 30
 
+        if font is None:
+            font = self.__font_path()
+
         # Create empty image
         image = self.__empty_image
 
         # Create font
         font = ImageFont.truetype(
-            self.__font_path(),
+            font,
             size=font_size
         )
 


### PR DESCRIPTION
My use case is to display emojis for a memory game.

It's unfortunate that Pillow ImageFont does [not support](https://github.com/python-pillow/Pillow/issues/4808) combining fonts, so that fallback fonts could be automatically used for characters not in the default. One possibility would be for us to [create](https://stackoverflow.com/a/35636648) and use font with the combinations manually. This `font` option would allow a user to do so themselves at least.