### PR TITLE
Add dependency versions

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,26 +1,26 @@
-flask python3-flask
-flask-cors python3-flask-cors
-flask-sockets python3-flask-sockets
-gevent python3-gevent
-gevent-websocket python3-gevent-websocket
-gpiozero python3-gpiozero
-imageio python3-imageio
-imutils python3-imutils
-luma.core python3-luma-core
-luma.oled python3-luma-oled
-matplotlib python3-matplotlib
-pitopcommon python3-pitopcommon
-pyinotify python3-pyinotify
-pynput python3-pynput
-pyv4l2camera python3-pyv4l2camera
-scipy python3-scipy
-simple_pid python3-simple-pid
-flask python3-flask
-flask-cors python3-flask-cors
-flask-sockets python3-flask-sockets
-gevent python3-gevent
-gevent-websocket python3-gevent-websocket
-dlib python3-dlib
-imutils python3-imutils
-wget python3-wget
-onnxruntime python3-onnxruntime
+flask python3-flask; PEP386
+flask-cors python3-flask-cors; PEP386
+flask-sockets python3-flask-sockets; PEP386
+gevent python3-gevent; PEP386
+gevent-websocket python3-gevent-websocket; PEP386
+gpiozero python3-gpiozero; PEP386
+imageio python3-imageio; PEP386
+imutils python3-imutils; PEP386
+luma.core python3-luma-core; PEP386
+luma.oled python3-luma-oled; PEP386
+matplotlib python3-matplotlib; PEP386
+pitopcommon python3-pitopcommon; PEP386
+pyinotify python3-pyinotify; PEP386
+pynput python3-pynput; PEP386
+pyv4l2camera python3-pyv4l2camera; PEP386
+scipy python3-scipy; PEP386
+simple_pid python3-simple-pid; PEP386
+flask python3-flask; PEP386
+flask-cors python3-flask-cors; PEP386
+flask-sockets python3-flask-sockets; PEP386
+gevent python3-gevent; PEP386
+gevent-websocket python3-gevent-websocket; PEP386
+dlib python3-dlib; PEP386
+imutils python3-imutils; PEP386
+wget python3-wget; PEP386
+onnxruntime python3-onnxruntime; PEP386

--- a/setup.py
+++ b/setup.py
@@ -77,73 +77,73 @@ __requires__ = [
     ####################################
     # Utilities - functions, IDs, etc. #
     ####################################
-    "pitopcommon==0.8.8",
+    "pitopcommon>=0.8.8,<0.9.0",
 
     #######
     # PMA #
     #######
     # To use GPIO & components
-    "gpiozero==1.6.2",
+    "gpiozero>=1.6.2,<1.7",
     # To perform operations with images
-    "imageio==2.4.1",
+    "imageio>=2.4.1,<2.5",
     # Camera uses numpy arrays for image data
-    "numpy==1.16.6",
+    "numpy>=1.16.0,<1.17",
     # Manage camera images
-    "Pillow==5.4.1",
+    "Pillow>=5.4.0,<5.5",
     # Camera communication
     "PyV4L2Camera==0.1a2",
     # IMU Calibration
-    "matplotlib==3.0.2",
-    "scipy==1.1.0",
+    "matplotlib>=3.0.0,<3.1",
+    "scipy>=1.1.0,<1.2",
 
     ############
     # Keyboard #
     ############
-    "pynput==1.4.2",
+    "pynput>=1.4.2,<1.5",
 
     ########
     # OLED #
     ########
-    "luma.core==2.3.1",
-    "luma.oled==3.8.1",
-    "monotonic==1.1",
-    "pyinotify==0.9.6",
+    "luma.core>=2.3.1,<2.4",
+    "luma.oled>=3.8.1,<3.9",
+    "monotonic>=1.1,<1.2",
+    "pyinotify>=0.9.6,<0.10",
 
     #########
     # Pulse #
     #########
-    "pyserial==3.4",
+    "pyserial>=3.4,<3.5",
 
     ##############
     # Algorithms #
     ##############
-    "simple_pid==0.2.4",
+    "simple_pid>=0.2.4,<0.3",
 
     #############
     # Webserver #
     #############
-    "flask==1.0.2",
-    "flask-cors==3.0.7",
-    "flask-sockets==0.2.1",
-    "gevent==1.3.7",
-    "gevent-websocket==0.10.1",
+    "flask>=1.0.2,<1.1",
+    "flask-cors>=3.0.7,<3.1",
+    "flask-sockets>=0.2.1,<0.3",
+    "gevent>=1.3.7,<1.4",
+    "gevent-websocket>=0.10.1,<0.11.0",
 
     #############################
     # Advanced image processing #
     #############################
-    "dlib==19.22.0",
-    "imutils==0.5.4",
-    "scikit-learn==0.20.2",
+    "dlib>=19.22.0,<19.23.0",
+    "imutils>=0.5.4,<0.6.0",
+    "scikit-learn>=0.20.2,<0.21.0",
 
     ###################
     # Use Model Files #
     ###################
-    "onnxruntime==1.8.1",
+    "onnxruntime>=1.8.1,<1.9",
 
     ########################
     # Download Model Files #
     ########################
-    "wget==3.2",
+    "wget>=3.2,<4.0",
 ]
 
 __extra_requires__ = {

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,11 @@ __requires__ = [
     # Manage camera images
     "Pillow>=5.4.0,<5.5",
     # Camera communication
-    "PyV4L2Camera==0.1a2",
+    # Release version is '0.1a2', but Debian package is '0.1.2'
+    # so we allow for both here
+    #
+    # TODO: build '0.1~a2' Debian package
+    "PyV4L2Camera>=0.1a2,<0.2",
     # IMU Calibration
     "matplotlib>=3.0.0,<3.1",
     "scipy>=1.1.0,<1.2",
@@ -138,7 +142,13 @@ __requires__ = [
     ###################
     # Use Model Files #
     ###################
-    "onnxruntime>=1.8.1,<1.9",
+    # python3-onnxruntime is currently 1.7.2-1 on Buster
+    # but PyPI has 1.7.0, 1.8.0 and 1.8.1
+    #
+    # We allow all because new features shouldn't affect our use-case
+    #
+    # TODO: Build python3-onnxruntime 1.8.1
+    "onnxruntime>=1.7.2,<1.9",
 
     ########################
     # Download Model Files #

--- a/setup.py
+++ b/setup.py
@@ -77,73 +77,73 @@ __requires__ = [
     ####################################
     # Utilities - functions, IDs, etc. #
     ####################################
-    "pitopcommon",
+    "pitopcommon==0.8.8",
 
     #######
     # PMA #
     #######
     # To use GPIO & components
-    "gpiozero",
+    "gpiozero==1.6.2",
     # To perform operations with images
-    "imageio",
+    "imageio==2.4.1",
     # Camera uses numpy arrays for image data
-    "numpy",
+    "numpy==1.16.6",
     # Manage camera images
-    "Pillow",
+    "Pillow==5.4.1",
     # Camera communication
-    "PyV4L2Camera",
+    "PyV4L2Camera==0.1a2",
     # IMU Calibration
-    "matplotlib",
-    "scipy",
+    "matplotlib==3.0.2",
+    "scipy==1.1.0",
 
     ############
     # Keyboard #
     ############
-    "pynput",
+    "pynput==1.4.2",
 
     ########
     # OLED #
     ########
-    "luma.oled",
-    "luma.core",
-    "monotonic",
-    "pyinotify",
+    "luma.core==2.3.1",
+    "luma.oled==3.8.1",
+    "monotonic==1.1",
+    "pyinotify==0.9.6",
 
     #########
     # Pulse #
     #########
-    "pyserial",
+    "pyserial==3.4",
 
     ##############
     # Algorithms #
     ##############
-    "simple_pid",
+    "simple_pid==0.2.4",
 
     #############
     # Webserver #
     #############
-    "flask",
-    "flask-cors",
-    "flask-sockets",
-    "gevent",
-    "gevent-websocket",
+    "flask==1.0.2",
+    "flask-cors==3.0.7",
+    "flask-sockets==0.2.1",
+    "gevent==1.3.7",
+    "gevent-websocket==0.10.1",
 
     #############################
     # Advanced image processing #
     #############################
-    "dlib",
-    "imutils",
-    "scikit-learn",
+    "dlib==19.22.0",
+    "imutils==0.5.4",
+    "scikit-learn==0.20.2",
 
     ###################
     # Use Model Files #
     ###################
-    "onnxruntime",
+    "onnxruntime==1.8.1",
 
     ########################
     # Download Model Files #
     ########################
-    "wget",
+    "wget==3.2",
 ]
 
 __extra_requires__ = {


### PR DESCRIPTION
Closes #383

`setup.py` defines Python dependency versions. Uses [`dh_python3`](https://www.systutorials.com/docs/linux/man/1-dh_python3/) to set Debian package version from this version.

Confirmed to install on Buster.

Missing version strings:
```
python3-monotonic
python3-sklearn
python3-pil
python3-serial
python3-numpy
```