### PR TITLE
OS-1102 Replace UsbCamera PyV4L2Camera dependency with cv2.VideoCapture

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -12,7 +12,6 @@ matplotlib python3-matplotlib; PEP386
 netifaces python3-netifaces; PEP386
 onnxruntime python3-onnxruntime; PEP386
 pyinotify python3-pyinotify; PEP386
-PyV4L2Camera python3-pyv4l2camera; PEP386
 RPi.GPIO python3-rpi.gpio; PEP386
 scipy python3-scipy; PEP386
 simple_pid python3-simple-pid; PEP386

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,6 @@ autodoc_mock_imports = [
     'mpl_toolkits',
     'PIL',
     'pyinotify',
-    'PyV4L2Camera',
     'RPi',
     'scipy',
     'serial',

--- a/pitop/camera/core/cameras/usb_camera.py
+++ b/pitop/camera/core/cameras/usb_camera.py
@@ -1,19 +1,11 @@
 from os import listdir
 from PIL import Image
 
+from pitop.core.import_opencv import import_opencv
 from pitop.core.ImageFunctions import convert
 
 
 valid_rotate_angles = [-270, -180, -90, 0, 90, 180, 270]
-
-
-def import_opencv():
-    try:
-        import cv2
-        return cv2
-    except (ImportError, ModuleNotFoundError):
-        raise ModuleNotFoundError(
-            "OpenCV Python library is not installed. You can install it by running 'sudo apt install python3-opencv libatlas-base-dev'.") from None
 
 
 class UsbCamera:

--- a/pitop/camera/core/cameras/usb_camera.py
+++ b/pitop/camera/core/cameras/usb_camera.py
@@ -26,10 +26,8 @@ class UsbCamera:
 
         VideoCapture = import_opencv().VideoCapture
 
-        # if no index is provided, loop over available video devices
-        indexes = self.list_device_indexes() if index is None else [index]
         self.__camera = None
-        self.index = None
+        self.index = -1 if index is None else index
 
         self._flip_top_bottom = flip_top_bottom
         self._flip_left_right = flip_left_right
@@ -48,15 +46,9 @@ class UsbCamera:
                 cap.set(4, resolution[1])
             return cap
 
-        for idx in indexes:
-            self.__camera = create_camera_object(idx, resolution)
-            if self.is_opened():
-                self.index = idx
-                break
-            else:
-                self.__camera = None
-
-        if self.__camera is None:
+        self.__camera = create_camera_object(self.index, resolution)
+        if not self.is_opened():
+            self.__camera = None
             raise IOError("Error opening camera. Make sure it's correctly connected via USB.") from None
 
     def __del__(self):
@@ -99,6 +91,7 @@ class UsbCamera:
         device_indexes = [int(dev[len("video"):]) for dev in device_names]
         # indexes >= 10 are for bcm2835, not useful for us
         camera_indexes = [i for i in device_indexes if i < 10]
+        camera_indexes.sort()
 
         # Not all devices actually provide video
         # eg: video1 can be a metadata device for video0
@@ -112,5 +105,4 @@ class UsbCamera:
             except Exception:
                 continue
 
-        indexes.sort()
         return indexes

--- a/pitop/core/ImageFunctions.py
+++ b/pitop/core/ImageFunctions.py
@@ -5,6 +5,7 @@ from numpy import (
 )
 from urllib.request import urlopen
 
+from pitop.core.import_opencv import import_opencv
 from pitop.common.formatting import is_url
 
 
@@ -14,16 +15,7 @@ def image_format_check(format):
 
 
 def convert(image, format="PIL"):
-
-    try:
-        from cv2 import (
-            cvtColor,
-            COLOR_BGR2RGB,
-            COLOR_RGB2BGR,
-        )
-    except (ImportError, ModuleNotFoundError):
-        raise ModuleNotFoundError(
-            "OpenCV Python library is not installed. You can install it by running 'sudo apt install python3-opencv libatlas-base-dev'.") from None
+    cv2 = import_opencv()
 
     image_format_check(format)
     format = format.lower()
@@ -38,13 +30,13 @@ def convert(image, format="PIL"):
         # Convert PIL to OpenCV
         cv_image = asarray(image)
         if image.mode == "RGB":
-            cv_image = cvtColor(cv_image, COLOR_RGB2BGR)
+            cv_image = cv2.cvtColor(cv_image, cv2.COLOR_RGB2BGR)
         return cv_image
     elif isinstance(image, ndarray) and format == "pil":
         # Convert OpenCV to PIL
         if len(image.shape) > 2 and image.shape[2] == 3:
             # If incoming image has 3 channels, convert from BGR to RGB
-            image = cvtColor(image, COLOR_BGR2RGB)
+            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         return Image.fromarray(image)
 
 

--- a/pitop/core/import_opencv.py
+++ b/pitop/core/import_opencv.py
@@ -1,0 +1,7 @@
+def import_opencv():
+    try:
+        import cv2
+        return cv2
+    except (ImportError, ModuleNotFoundError):
+        raise ModuleNotFoundError(
+            "OpenCV Python library is not installed. You can install it by running 'sudo apt install python3-opencv libatlas-base-dev'.") from None

--- a/pitop/processing/core/vision_functions.py
+++ b/pitop/processing/core/vision_functions.py
@@ -1,14 +1,7 @@
 from matplotlib import colors
 from imutils import grab_contours
 
-
-def import_opencv():
-    try:
-        import cv2
-        return cv2
-    except (ImportError, ModuleNotFoundError):
-        raise ModuleNotFoundError(
-            "OpenCV Python library is not installed. You can install it by running 'sudo apt install python3-opencv libatlas-base-dev'.") from None
+from pitop.core.import_opencv import import_opencv
 
 
 def import_dlib():

--- a/setup.py
+++ b/setup.py
@@ -99,12 +99,6 @@ __requires__ = [
     "numpy>=1.16.0,<1.17",
     # Manage camera images
     "Pillow>=5.4.0,<5.5",
-    # Camera communication
-    # Release version is '0.1a2', but Debian package is '0.1.2'
-    # so we allow for both here
-    #
-    # TODO: build '0.1~a2' Debian package
-    "PyV4L2Camera>=0.1a2,<0.2",
     # IMU Calibration
     "matplotlib>=3.0.0,<3.1",
     "scipy>=1.1.0,<1.2",

--- a/tests/test_ball_detector.py
+++ b/tests/test_ball_detector.py
@@ -5,8 +5,6 @@ from unittest.mock import Mock
 modules_to_patch = [
     "imageio",
     "pitop.common",
-    "PyV4L2Camera.camera",
-    "PyV4L2Camera.exceptions",
 ]
 for module in modules_to_patch:
     modules[module] = Mock()

--- a/tests/test_face_and_emotion_detector.py
+++ b/tests/test_face_and_emotion_detector.py
@@ -6,8 +6,6 @@ import os
 modules_to_patch = [
     "imageio",
     "pitop.common",
-    "PyV4L2Camera.camera",
-    "PyV4L2Camera.exceptions",
 ]
 for module in modules_to_patch:
     modules[module] = Mock()


### PR DESCRIPTION
This appears to work just as well on buster with all the examples, I am yet to test bullseye.

I found that a warning would be printed when creating a cv2.VideoCapture with an invalid device as part of the scan in  `list_device_indexes` - `Unable to stop the stream: Invalid argument`. I wasn't able to silence these but found that we can avoid doing this scan ourselves by passing index -1 to VideoCapture, which makes it find the first working device itself (works even when this is not video0).

Also I moved import_opencv helper into pitop.core so it could be shared between the processing module, ImageFunctions, and now UsbCamera.