### PR TITLE
Changed all D4 examples to D0

### DIFF
--- a/examples/pma/buzzer.py
+++ b/examples/pma/buzzer.py
@@ -1,7 +1,7 @@
 from pitop import Buzzer
 from time import sleep
 
-buzzer = Buzzer("D4")
+buzzer = Buzzer("D0")
 
 buzzer.on()  # Set buzzer sound on
 print(buzzer.value)  # Return 1 while the buzzer is on

--- a/pitop/pma/button.py
+++ b/pitop/pma/button.py
@@ -46,25 +46,25 @@ class Button(Stateful, Recreatable, gpiozero_Button):
         contrast, the close method provides a means of ensuring that the object
         is shut down.
 
-        For example, if you have a buzzer connected to port D4, but then wish
+        For example, if you have a buzzer connected to port D0, but then wish
         to attach an LED instead:
 
             >>> from pitop import Buzzer, LED
-            >>> bz = Buzzer("D4")
+            >>> bz = Buzzer("D0")
             >>> bz.on()
             >>> bz.off()
             >>> bz.close()
-            >>> led = LED("D4")
+            >>> led = LED("D0")
             >>> led.blink()
 
         :class:`Device` descendents can also be used as context managers using
         the :keyword:`with` statement. For example:
 
             >>> from pitop import Buzzer, LED
-            >>> with Buzzer("D4") as bz:
+            >>> with Buzzer("D0") as bz:
             ...     bz.on()
             ...
-            >>> with LED("D4") as led:
+            >>> with LED("D0") as led:
             ...     led.on()
             ...
         """

--- a/pitop/pma/buzzer.py
+++ b/pitop/pma/buzzer.py
@@ -44,25 +44,25 @@ class Buzzer(Stateful, Recreatable, gpiozero_Buzzer):
         contrast, the close method provides a means of ensuring that the object
         is shut down.
 
-        For example, if you have a buzzer connected to port D4, but then wish
+        For example, if you have a buzzer connected to port D0, but then wish
         to attach an LED instead:
 
             >>> from pitop import Buzzer, LED
-            >>> bz = Buzzer("D4")
+            >>> bz = Buzzer("D0")
             >>> bz.on()
             >>> bz.off()
             >>> bz.close()
-            >>> led = LED("D4")
+            >>> led = LED("D0")
             >>> led.blink()
 
         :class:`Device` descendents can also be used as context managers using
         the :keyword:`with` statement. For example:
 
             >>> from pitop import Buzzer, LED
-            >>> with Buzzer("D4") as bz:
+            >>> with Buzzer("D0") as bz:
             ...     bz.on()
             ...
-            >>> with LED("D4") as led:
+            >>> with LED("D0") as led:
             ...     led.on()
             ...
         """

--- a/pitop/pma/led.py
+++ b/pitop/pma/led.py
@@ -45,25 +45,25 @@ class LED(Stateful, Recreatable, gpiozero_LED):
         contrast, the close method provides a means of ensuring that the object
         is shut down.
 
-        For example, if you have a buzzer connected to port D4, but then wish
+        For example, if you have a buzzer connected to port D0, but then wish
         to attach an LED instead:
 
             >>> from pitop import Buzzer, LED
-            >>> bz = Buzzer("D4")
+            >>> bz = Buzzer("D0")
             >>> bz.on()
             >>> bz.off()
             >>> bz.close()
-            >>> led = LED("D4")
+            >>> led = LED("D0")
             >>> led.blink()
 
         :class:`Device` descendents can also be used as context managers using
         the :keyword:`with` statement. For example:
 
             >>> from pitop import Buzzer, LED
-            >>> with Buzzer("D4") as bz:
+            >>> with Buzzer("D0") as bz:
             ...     bz.on()
             ...
-            >>> with LED("D4") as led:
+            >>> with LED("D0") as led:
             ...     led.on()
             ...
         """

--- a/pitop/pma/ultrasonic_sensor.py
+++ b/pitop/pma/ultrasonic_sensor.py
@@ -131,25 +131,25 @@ class UltrasonicSensor(Stateful, Recreatable):
         contrast, the close method provides a means of ensuring that the object
         is shut down.
 
-        For example, if you have a buzzer connected to port D4, but then wish
+        For example, if you have a buzzer connected to port D0, but then wish
         to attach an LED instead:
 
             >>> from pitop import Buzzer, LED
-            >>> bz = Buzzer("D4")
+            >>> bz = Buzzer("D0")
             >>> bz.on()
             >>> bz.off()
             >>> bz.close()
-            >>> led = LED("D4")
+            >>> led = LED("D0")
             >>> led.blink()
 
         :class:`Device` descendents can also be used as context managers using
         the :keyword:`with` statement. For example:
 
             >>> from pitop import Buzzer, LED
-            >>> with Buzzer("D4") as bz:
+            >>> with Buzzer("D0") as bz:
             ...     bz.on()
             ...
-            >>> with LED("D4") as led:
+            >>> with LED("D0") as led:
             ...     led.on()
             ...
         """

--- a/pitop/protoplus/sensors.py
+++ b/pitop/protoplus/sensors.py
@@ -28,25 +28,25 @@ class DistanceSensor(gpiozero_DistanceSensor):
         contrast, the close method provides a means of ensuring that the object
         is shut down.
 
-        For example, if you have a buzzer connected to port D4, but then wish
+        For example, if you have a buzzer connected to port D0, but then wish
         to attach an LED instead:
 
             >>> from pitop import Buzzer, LED
-            >>> bz = Buzzer("D4")
+            >>> bz = Buzzer("D0")
             >>> bz.on()
             >>> bz.off()
             >>> bz.close()
-            >>> led = LED("D4")
+            >>> led = LED("D0")
             >>> led.blink()
 
         :class:`Device` descendents can also be used as context managers using
         the :keyword:`with` statement. For example:
 
             >>> from pitop import Buzzer, LED
-            >>> with Buzzer("D4") as bz:
+            >>> with Buzzer("D0") as bz:
             ...     bz.on()
             ...
-            >>> with LED("D4") as led:
+            >>> with LED("D0") as led:
             ...     led.on()
             ...
         """


### PR DESCRIPTION
As it currently stands any code using a digital output such as a buzzer, will not work properly when connected to port D4. This is caused by the miniscreen using the same pin as port D4 (SPI 1 clash - [related issue here](https://github.com/pi-top/pi-top-Python-SDK/issues/337)). 

Unfortunately we have a lot of examples that suggest using D4 as the default port, so a lot of users will immediately run into this problem. I've changed every example port to D0 instead of D4. The underlying issue of D4 not working properly will be address in a future fix.