### PR TITLE
[buster] Fix miniscreen issues

### DIFF
--- a/examples/system/pitop_load_configuration.py
+++ b/examples/system/pitop_load_configuration.py
@@ -6,7 +6,7 @@ from pitop import Pitop
 pitop = Pitop.from_file("/home/pi/my_custom_config.json")
 
 # Check the loaded configuration
-print(pitop.component_config)
+print(pitop.config)
 
 # Do something with your device
 pitop.red_led.on()

--- a/examples/system/pitop_load_configuration.py
+++ b/examples/system/pitop_load_configuration.py
@@ -16,4 +16,4 @@ pitop.red_led.off()
 pitop.drive.stop()
 
 # Check the state of all the components attached to the Pitop object
-print(pitop.component_state)
+pitop.print_state()

--- a/examples/system/pitop_overview.py
+++ b/examples/system/pitop_overview.py
@@ -39,10 +39,10 @@ def display_gif_and_exit():
     keep_running = False
 
 
-pitop.select_button.when_pressed = display_gif_and_exit
-pitop.cancel_button.when_pressed = display_gif_and_exit
-pitop.up_button.when_pressed = display_gif_and_exit
-pitop.down_button.when_pressed = display_gif_and_exit
+pitop.miniscreen.select_button.when_pressed = display_gif_and_exit
+pitop.miniscreen.cancel_button.when_pressed = display_gif_and_exit
+pitop.miniscreen.up_button.when_pressed = display_gif_and_exit
+pitop.miniscreen.down_button.when_pressed = display_gif_and_exit
 
 pitop.miniscreen.display_multiline_text("Press any button...", font_size=25)
 

--- a/pitop/miniscreen/oled/assistant.py
+++ b/pitop/miniscreen/oled/assistant.py
@@ -24,7 +24,7 @@ class MiniscreenAssistant:
         return image
 
     def get_recommended_text_pos(self):
-        return self.top_left
+        return self.top_left()
 
     def get_recommended_font_size(self):
         return 30

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -325,11 +325,11 @@ class OLED:
         :param bool invert: Set to True to flip the on/off state of each pixel in the image
         """
 
-        def format_multiline_text(text):
+        def format_multiline_text(text, font, font_size):
             def get_text_size(text):
                 return ImageDraw.Draw(self.assistant.empty_image).textsize(
                     text=str(text),
-                    font=font,
+                    font=ImageFont.truetype(font, size=font_size),
                     spacing=0,
                 )
 
@@ -353,9 +353,6 @@ class OLED:
                     remaining = remaining - (word_width + space_width)
             return "\n".join(output_text)
 
-        # Format text
-        text = format_multiline_text(text)
-
         if xy is None:
             xy = self.assistant.get_recommended_text_pos()
 
@@ -364,6 +361,9 @@ class OLED:
 
         if font is None:
             font = self.assistant.get_recommended_font_path(font_size)
+
+        # Format text
+        text = format_multiline_text(text, font, font_size)
 
         # Create empty image
         image = self.assistant.empty_image


### PR DESCRIPTION
#### Summary

- Miniscreen's `get_recommended_text_pos` now returns a value (previously was a reference to a function).
- When drawing multiline text, `font` & `font_size` are considered in order to break input string correctly.

Also:
- Updates references to deprecated functions in example.
- Reference buttons through `Pitop.miniscreen` in example.
