### PR TITLE
Fix path to default font in oled assistant

### DIFF
--- a/pitop/miniscreen/oled/assistant.py
+++ b/pitop/miniscreen/oled/assistant.py
@@ -35,7 +35,7 @@ class MiniscreenAssistant:
     def get_recommended_font_path(self, size=15):
         font_path = self.get_regular_font_path()
         if size < 12:
-            font_path = self.get_mono_font()
+            font_path = self.get_mono_font_path()
 
         return font_path
 


### PR DESCRIPTION
Fixes issue when trying to use miniscreen "display text" functions using `font_size < 12`:

```
Traceback (most recent call last):
  File "test.py", line 60, in <module>
    say(descriptions.get(location, f'{location}... Which way to go?'))
  File "test.py", line 34, in say
    screen.display_multiline_text(text, font_size=10)
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 367, in display_multiline_text
    text = format_multiline_text(text, font, font_size)
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 336, in format_multiline_text
    space_width, _ = get_text_size(" ")
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/oled.py", line 331, in get_text_size
    font=ImageFont.truetype(font, size=font_size),
  File "/usr/lib/python3/dist-packages/PIL/ImageFont.py", line 280, in truetype
    return FreeTypeFont(font, size, index, encoding, layout_engine)
  File "/usr/lib/python3/dist-packages/PIL/ImageFont.py", line 147, in __init__
    self.font_bytes = font.read()
AttributeError: 'FreeTypeFont' object has no attribute 'read'
```

The `get_recommended_font` method wasn't returning a path but a font object.