### PR TITLE
Miniscreen: move lockfile management to another file

### DIFF
--- a/pitop/miniscreen/oled/core/__init__.py
+++ b/pitop/miniscreen/oled/core/__init__.py
@@ -1,2 +1,3 @@
 from .device_controller import OledDeviceController
 from .fps_regulator import FPS_Regulator
+from .lock import MiniscreenLockFileMonitor

--- a/pitop/miniscreen/oled/core/lock.py
+++ b/pitop/miniscreen/oled/core/lock.py
@@ -1,0 +1,35 @@
+from threading import Thread
+
+from pyinotify import IN_CLOSE_WRITE, IN_OPEN, Notifier, ProcessEvent, WatchManager
+
+
+class MiniscreenLockFileMonitor:
+    def __init__(self):
+        self.thread = Thread(target=self._monitor_lockfile)
+        self.when_user_stops_using_oled = None
+        self.when_user_starts_using_oled = None
+
+    def _monitor_lockfile(self):
+        eh = ProcessEvent()
+        events_to_watch = 0
+        if self.when_user_stops_using_oled:
+            eh.process_IN_CLOSE_WRITE = lambda event: self.when_user_stops_using_oled()
+            events_to_watch = events_to_watch | IN_CLOSE_WRITE
+        if self.when_user_starts_using_oled:
+            eh.process_IN_OPEN = lambda event: self.when_user_starts_using_oled()
+            events_to_watch = events_to_watch | IN_OPEN
+
+        wm = WatchManager()
+        wm.add_watch(self.__controller.lock.path, events_to_watch)
+        notifier = Notifier(wm, eh)
+        notifier.loop()
+
+    def start(self):
+        self.stop()
+        self.thread = Thread(target=self._monitor_lockfile)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def stop(self):
+        if self.thread is not None and self.thread.is_alive():
+            self.thread.join(0)

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -608,11 +608,22 @@ class OLED:
                 break
 
     @property
-    def _when_user_starts_using_oled(self):
+    def when_user_controlled(self):
+        """Function to call when user takes control of the miniscreen.
+
+        This is used by pt-miniscreen to update its 'user-controlled'
+        application state.
+        """
         return self.lock_file_monitor.when_user_starts_using_oled
 
-    @_when_user_starts_using_oled.setter
-    def _when_user_starts_using_oled(self, callback):
+    @when_user_controlled.setter
+    def when_user_controlled(self, callback):
+        """Setter for function to call when user takes control of the
+        miniscreen.
+
+        This is used by pt-miniscreen to update its 'user-controlled'
+        application state.
+        """
         if not callable(callback):
             raise ValueError("Callback must be callable")
 
@@ -621,11 +632,23 @@ class OLED:
         self.lock_file_monitor.start()
 
     @property
-    def _when_user_stops_using_oled(self):
+    def when_system_controlled(self):
+        """Function to call when user gives back control of the miniscreen to
+        the system.
+
+        This is used by pt-miniscreen to update its 'user-controlled'
+        application state.
+        """
         return self.lock_file_monitor.when_user_stops_using_oled
 
-    @_when_user_stops_using_oled.setter
-    def _when_user_stops_using_oled(self, callback):
+    @when_system_controlled.setter
+    def when_system_controlled(self, callback):
+        """Setter for function to call when user gives back control of the
+        miniscreen to the system.
+
+        This is used by pt-miniscreen to update its 'user-controlled'
+        application state.
+        """
         if not callable(callback):
             raise ValueError("Callback must be callable")
 

--- a/pitop/miniscreen/oled/oled.py
+++ b/pitop/miniscreen/oled/oled.py
@@ -656,6 +656,26 @@ class OLED:
         # Lockfile thread needs to be restarted to get updated callback reference
         self.lock_file_monitor.start()
 
+    @property
+    def _when_user_starts_using_oled(self):
+        """Deprecated function."""
+        return self.when_user_controlled
+
+    @_when_user_starts_using_oled.setter
+    def _when_user_starts_using_oled(self, callback):
+        """Deprecated function."""
+        self.when_user_controlled(callback)
+
+    @property
+    def _when_user_stops_using_oled(self):
+        """Deprecated function."""
+        return self.when_system_controlled
+
+    @_when_user_stops_using_oled.setter
+    def _when_user_stops_using_oled(self, callback):
+        """Deprecated function."""
+        self.when_system_controlled(callback)
+
     def __cleanup(self):
         self.stop_animated_image()
         self.lock_file_monitor.stop()


### PR DESCRIPTION
This is an improvement in decoupling the miniscreen components and giving things better names.

In addition, the lock-related methods are now more appropriately named.
Before:
```
miniscreen._when_user_starts_using_oled
miniscreen._when_user_stops_using_oled
```

Now:
```
miniscreen.when_user_controlled
miniscreen.when_system_controlled
```

Deprecated functions are provided to ensure that Buster will continue to work.