### PR TITLE
Correct name of opencv-python in setup.cfg and py3dist-overrides

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -13,7 +13,7 @@ matplotlib python3-matplotlib; PEP386
 netifaces python3-netifaces; PEP386
 # Numpy in Debian has epoch version 1
 numpy python3-numpy; s/^/1:/
-opencv python3-opencv; PEP386
+opencv-python python3-opencv; PEP386
 pyinotify python3-pyinotify; PEP386
 RPi.GPIO python3-rpi.gpio; PEP386
 scipy python3-scipy; PEP386

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     # Device Communication
     pyzmq >= 20.0.0
     # Images
-    opencv >= 4.5.1
+    opencv-python >= 4.5.1
     #######
     # PMA #
     #######


### PR DESCRIPTION
It seems the python package doesn't install... and never has since #443?!

opencv is not found: https://pypi.org/simple/opencv/
it's opencv-python:  https://pypi.org/simple/opencv-python/