### PR TITLE
Navigation controller refactor

### DIFF
--- a/pitop/robotics/navigation/core/driving_manager.py
+++ b/pitop/robotics/navigation/core/driving_manager.py
@@ -68,3 +68,9 @@ class DrivingManager:
             self._full_speed_deceleration_angle
         )
         self.pid.heading_update(deceleration_angle=self.deceleration_angle)
+
+    def get_new_angular_speed(self, angle_error):
+        return self.max_angular_velocity * self.pid.heading(angle_error)
+
+    def get_new_linear_speed(self, distance_error):
+        return self.max_velocity * self.pid.distance(distance_error)

--- a/pitop/robotics/navigation/core/measurement_scheduler.py
+++ b/pitop/robotics/navigation/core/measurement_scheduler.py
@@ -1,0 +1,48 @@
+import sched
+import time
+from threading import Event, Thread
+
+
+class MeasurementScheduler:
+    def __init__(self, measurement_frequency, odometry_function, state_tracker):
+        self.state_tracker = state_tracker
+        self.odometry_func = odometry_function
+        self._measurement_dt = 1.0 / measurement_frequency
+
+        self._pose_prediction_scheduler = Thread(
+            target=self.__measurement_scheduler, daemon=True
+        )
+        self._new_pose_event = Event()
+
+    def start(self):
+        self._pose_prediction_scheduler.start()
+
+    def wait_for_measurement(self):
+        self._new_pose_event.wait()
+
+    def __measurement_scheduler(self):
+        s = sched.scheduler(time.time, time.sleep)
+        current_time = time.time()
+        s.enterabs(
+            current_time + self._measurement_dt,
+            1,
+            self.__measurement_loop,
+            (s, current_time),
+        )
+        s.run()
+
+    def __measurement_loop(self, s, previous_time):
+        current_time = time.time()
+        self.state_tracker.add_measurements(
+            odom_measurements=self.odometry_func(), dt=current_time - previous_time
+        )
+
+        self._new_pose_event.set()
+        self._new_pose_event.clear()
+
+        s.enterabs(
+            current_time + self._measurement_dt,
+            1,
+            self.__measurement_loop,
+            (s, current_time),
+        )

--- a/pitop/robotics/navigation/core/measurement_scheduler.py
+++ b/pitop/robotics/navigation/core/measurement_scheduler.py
@@ -17,26 +17,24 @@ class MeasurementScheduler:
         self._measurement_dt = 1.0 / measurement_frequency
 
         self._new_measurement_event = Event()
-        self._measurement_prediction_scheduler = Thread(
-            target=self.__measurement_scheduler, daemon=True
-        )
+        self._measurement_prediction_scheduler = Thread(target=self.start, daemon=True)
         self._measurement_prediction_scheduler.start()
 
     def wait_for_measurement(self):
         self._new_measurement_event.wait()
 
-    def __measurement_scheduler(self):
+    def start(self):
         s = sched.scheduler(time.time, time.sleep)
         current_time = time.time()
         s.enterabs(
             current_time + self._measurement_dt,
             1,
-            self.__measurement_loop,
+            self.loop,
             (s, current_time),
         )
         s.run()
 
-    def __measurement_loop(self, s, previous_time):
+    def loop(self, s, previous_time):
         current_time = time.time()
         self.state_tracker.add_measurements(
             odom_measurements=self.measurement_func(), dt=current_time - previous_time
@@ -48,6 +46,6 @@ class MeasurementScheduler:
         s.enterabs(
             current_time + self._measurement_dt,
             1,
-            self.__measurement_loop,
+            self.loop,
             (s, current_time),
         )

--- a/pitop/robotics/navigation/core/utils.py
+++ b/pitop/robotics/navigation/core/utils.py
@@ -9,3 +9,28 @@ def normalize_angle(angle):
     :return: angle in radians normalized to range -pi to +pi
     """
     return (angle + math.pi) % (2 * math.pi) - math.pi
+
+
+def verify_callback(callback):
+    if callback is None:
+        return None
+    if not callable(callback):
+        raise ValueError("callback should be a callable function.")
+
+    from inspect import getfullargspec
+
+    arg_spec = getfullargspec(callback)
+    number_of_arguments = len(arg_spec.args)
+    number_of_default_arguments = (
+        len(arg_spec.defaults) if arg_spec.defaults is not None else 0
+    )
+    if number_of_arguments == 0:
+        return callback
+    if (
+        arg_spec.args[0] in ("self", "_mock_self")
+        and (number_of_arguments - number_of_default_arguments) == 1
+    ):
+        return callback
+    if number_of_arguments != number_of_default_arguments:
+        raise ValueError("callback should have no non-default keyword arguments.")
+    return callback

--- a/pitop/robotics/navigation/navigation_controller.py
+++ b/pitop/robotics/navigation/navigation_controller.py
@@ -218,7 +218,7 @@ class NavigationController(DriveController):
     def stop_navigation(self):
         # don't call callback if user has terminated navigation manually
         self._on_finish = None
-        self.navigator._stop_triggered = True
+        self.navigator.stop_triggered = True
         try:
             self._nav_thread.join()
         except Exception:
@@ -230,7 +230,7 @@ class NavigationController(DriveController):
 
     def __navigation_started(self):
         self.in_progress = True
-        self.navigator._stop_triggered = False
+        self.navigator.stop_triggered = False
 
     def __navigation_finished(self):
         self.in_progress = False

--- a/pitop/robotics/navigation/navigator.py
+++ b/pitop/robotics/navigation/navigator.py
@@ -28,14 +28,10 @@ class Navigator:
 
     def navigate(self, position, angle):
         position_generators = []
-        if position is not None and not self.reached_position(
-            position=position, angle=None
-        ):
+        if position is not None:
             position_generators.append(self._set_course_heading(position))
             position_generators.append(self._drive_to_position_goal(position))
         if angle is not None:
-            position_generators.append(self._rotate_to_angle_goal(math.radians(angle)))
-            # TODO: fine tune the PID controller to avoid running this twice
             position_generators.append(self._rotate_to_angle_goal(math.radians(angle)))
 
         for generator in position_generators:
@@ -71,6 +67,7 @@ class Navigator:
             angle_error = self.__get_angle_error(
                 current_angle=theta, target_angle=math.atan2(y_diff, x_diff)
             )
+
             if self.goal_criteria.angle(angle_error):
                 break
 

--- a/pitop/robotics/navigation/navigator.py
+++ b/pitop/robotics/navigation/navigator.py
@@ -1,0 +1,145 @@
+import math
+
+import numpy as np
+
+from .core.driving_manager import DrivingManager
+from .core.goal_criteria import GoalCriteria
+from .core.utils import normalize_angle
+
+
+class Navigator:
+    def __init__(
+        self, max_motor_speed, max_robot_angular_speed, measurement_input_function
+    ) -> None:
+        if not callable(measurement_input_function):
+            raise AttributeError(
+                "Argument 'measurement_input_function' must be a function"
+            )
+
+        self.measurement_input_function = measurement_input_function
+        self.backwards = False
+        self._stop_triggered = False
+
+        self._goal_criteria = GoalCriteria()
+        self._drive_manager = DrivingManager(
+            max_motor_speed=max_motor_speed,
+            max_angular_speed=max_robot_angular_speed,
+        )
+
+    def navigate(self, position, angle):
+        generators = []
+        if position is not None:
+            x, y = position
+            generators.append(self._set_course_heading(x, y))
+            generators.append(self._drive_to_position_goal(x, y))
+        if angle is not None:
+            generators.append(self._rotate_to_angle_goal(math.radians(angle)))
+
+        for generator in generators:
+            try:
+                for linear_speed, angular_speed in generator:
+                    yield linear_speed, angular_speed
+            except StopIteration:
+                yield 0, 0
+                self._drive_manager.pid.reset()
+
+        yield 0, 0
+
+    def _set_course_heading(self, x_goal, y_goal):
+        while not self._stop_triggered:
+            x, y, theta = self.measurement_input_function()
+
+            x_diff, y_diff = self.__get_position_error(
+                x=x, x_goal=x_goal, y=y, y_goal=y_goal
+            )
+            angle_error = self.__get_angle_error(
+                current_angle=theta, target_angle=math.atan2(y_diff, x_diff)
+            )
+
+            if self._goal_criteria.angle(angle_error):
+                break
+
+            linear_speed = 0
+            angular_speed = self._get_new_angular_speed(angle_error=angle_error)
+            yield linear_speed, angular_speed
+
+    def _drive_to_position_goal(self, x_goal, y_goal):
+        while not self._stop_triggered:
+            x, y, theta = self.measurement_input_function()
+
+            x_diff, y_diff = self.__get_position_error(
+                x=x, x_goal=x_goal, y=y, y_goal=y_goal
+            )
+            angle_error = self.__get_angle_error(
+                current_angle=theta, target_angle=math.atan2(y_diff, x_diff)
+            )
+            distance_error = (
+                -np.hypot(x_diff, y_diff)
+                if not self.backwards
+                else np.hypot(x_diff, y_diff)
+            )
+
+            if self._goal_criteria.distance(
+                distance_error=distance_error, angle_error=angle_error
+            ):
+                break
+
+            angular_speed = self._get_new_angular_speed(angle_error=angle_error)
+            linear_speed = self.__get_new_linear_speed(distance_error=distance_error)
+            yield linear_speed, angular_speed
+
+    def _rotate_to_angle_goal(self, theta_goal):
+        while not self._stop_triggered:
+            _, _, theta = self.measurement_input_function()
+
+            angle_error = self.__get_angle_error(
+                current_angle=theta, target_angle=theta_goal
+            )
+
+            if self._goal_criteria.angle(angle_error):
+                break
+
+            linear_speed = 0
+            angular_speed = self._get_new_angular_speed(angle_error=angle_error)
+            yield linear_speed, angular_speed
+
+    def _get_new_angular_speed(self, angle_error):
+        return (
+            self._drive_manager.max_angular_velocity
+            * self._drive_manager.pid.heading(angle_error)
+        )
+
+    def __get_new_linear_speed(self, distance_error):
+        return self._drive_manager.max_velocity * self._drive_manager.pid.distance(
+            distance_error
+        )
+
+    def __get_angle_error(self, current_angle, target_angle):
+        return normalize_angle(current_angle - target_angle)
+
+    def __get_position_error(self, x, x_goal, y, y_goal):
+        x_diff = x_goal - x if not self.backwards else x - x_goal
+        y_diff = y_goal - y if not self.backwards else y - y_goal
+        return x_diff, y_diff
+
+    @property
+    def angular_speed_factor(self):
+        return self._drive_manager.angular_speed_factor
+
+    @angular_speed_factor.setter
+    def angular_speed_factor(self, speed_factor):
+        if not 0.0 < speed_factor <= 1.0:
+            raise ValueError("Value must be in the range 0.0 < speed_factor <= 1.0")
+        self._drive_manager.update_angular_speed(speed_factor)
+        self._goal_criteria.update_angular_speed(speed_factor)
+
+    @property
+    def linear_speed_factor(self):
+        return self._drive_manager.linear_speed_factor
+
+    @linear_speed_factor.setter
+    def linear_speed_factor(self, speed_factor: float):
+        if not 0.0 < speed_factor <= 1.0:
+            raise ValueError("Value must be in the range 0.0 < speed_factor <= 1.0")
+        self._drive_manager.update_linear_speed(speed_factor)
+        self._goal_criteria.update_linear_speed(speed_factor)

--- a/tests/test_drive_controller.py
+++ b/tests/test_drive_controller.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock, patch
 modules_to_patch = [
     "pitop.camera.camera",
     "atexit",
-    "pyinput",
     "smbus2",
 ]
 for module in modules_to_patch:

--- a/tests/test_drive_controller.py
+++ b/tests/test_drive_controller.py
@@ -5,8 +5,8 @@ from unittest.mock import Mock, patch
 modules_to_patch = [
     "pitop.camera.camera",
     "atexit",
-    "numpy",
-    "pitop.common",
+    "pyinput",
+    "smbus2",
 ]
 for module in modules_to_patch:
     modules[module] = Mock()
@@ -110,10 +110,10 @@ class DriveControllerTestCase(TestCase):
 
         test_values = [
             [0, 0, 0, 0, 0],
-            [0.363, 0.428, 1, 1, 0],
-            [0.394, 0.428, 1, 1, 1],
+            [0.38, 0.447, 1, 1, 0],
+            [0.412, 0.447, 1, 1, 1],
             [0.276, 0.324, 0.3, 0.3, 0],
-            [0.391, 0.428, 0.3, 0.3, 0.8],
+            [0.408, 0.447, 0.3, 0.3, 0.8],
         ]
         for (
             exp_rpm_left,

--- a/tests/test_navigation_controller.py
+++ b/tests/test_navigation_controller.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 modules_to_patch = [
     "atexit",
-    "pitop.common",
+    "smbus2",
 ]
 for module in modules_to_patch:
     modules[module] = Mock()
@@ -12,7 +12,6 @@ for module in modules_to_patch:
 import math
 from time import sleep
 
-from pitop.robotics.drive_controller import DriveController
 from pitop.robotics.navigation.navigation_controller import NavigationController
 
 
@@ -183,31 +182,31 @@ class TestNavigationController(TestCase):
         )
 
         self.assertEqual(
-            navigation_controller._goal_criteria._max_distance_error,
-            navigation_controller._goal_criteria._full_speed_distance_error
+            navigation_controller.navigator._goal_criteria._max_distance_error,
+            navigation_controller.navigator._goal_criteria._full_speed_distance_error
             * linear_speed_factor,
         )
         self.assertEqual(
-            navigation_controller._goal_criteria._max_angle_error,
-            navigation_controller._goal_criteria._full_speed_angle_error
+            navigation_controller.navigator._goal_criteria._max_angle_error,
+            navigation_controller.navigator._goal_criteria._full_speed_angle_error
             * angular_speed_factor,
         )
 
         self.assertEqual(
-            navigation_controller._drive_manager.pid.distance.Kp,
+            navigation_controller.navigator._drive_manager.pid.distance.Kp,
             1
             / (
-                navigation_controller._drive_manager._full_speed_deceleration_distance
+                navigation_controller.navigator._drive_manager._full_speed_deceleration_distance
                 * linear_speed_factor
             ),
         )
 
         self.assertEqual(
-            navigation_controller._drive_manager.pid.heading.Kp,
+            navigation_controller.navigator._drive_manager.pid.heading.Kp,
             1
             / (
                 math.radians(
-                    navigation_controller._drive_manager._full_speed_deceleration_angle
+                    navigation_controller.navigator._drive_manager._full_speed_deceleration_angle
                 )
                 * angular_speed_factor
             ),
@@ -216,7 +215,7 @@ class TestNavigationController(TestCase):
     @staticmethod
     @patch("pitop.robotics.drive_controller.EncoderMotor", EncoderMotorSim)
     def get_navigation_controller():
-        return NavigationController(drive_controller=DriveController())
+        return NavigationController()
 
     def robot_state_assertions(
         self, navigation_controller, x_expected, y_expected, angle_expected

--- a/tests/test_navigation_controller.py
+++ b/tests/test_navigation_controller.py
@@ -182,31 +182,31 @@ class TestNavigationController(TestCase):
         )
 
         self.assertEqual(
-            navigation_controller.navigator._goal_criteria._max_distance_error,
-            navigation_controller.navigator._goal_criteria._full_speed_distance_error
+            navigation_controller.navigator.goal_criteria._max_distance_error,
+            navigation_controller.navigator.goal_criteria._full_speed_distance_error
             * linear_speed_factor,
         )
         self.assertEqual(
-            navigation_controller.navigator._goal_criteria._max_angle_error,
-            navigation_controller.navigator._goal_criteria._full_speed_angle_error
+            navigation_controller.navigator.goal_criteria._max_angle_error,
+            navigation_controller.navigator.goal_criteria._full_speed_angle_error
             * angular_speed_factor,
         )
 
         self.assertEqual(
-            navigation_controller.navigator._drive_manager.pid.distance.Kp,
+            navigation_controller.navigator.drive_manager.pid.distance.Kp,
             1
             / (
-                navigation_controller.navigator._drive_manager._full_speed_deceleration_distance
+                navigation_controller.navigator.drive_manager._full_speed_deceleration_distance
                 * linear_speed_factor
             ),
         )
 
         self.assertEqual(
-            navigation_controller.navigator._drive_manager.pid.heading.Kp,
+            navigation_controller.navigator.drive_manager.pid.heading.Kp,
             1
             / (
                 math.radians(
-                    navigation_controller.navigator._drive_manager._full_speed_deceleration_angle
+                    navigation_controller.navigator.drive_manager._full_speed_deceleration_angle
                 )
                 * angular_speed_factor
             ),


### PR DESCRIPTION
- Decouple the calculation of `linear_speed` and `angular_speed` from `NavigationController` into the `Navigator` class. These parameters are now provided in the form of a generator, and it's used by the `NavigationController` in its `__navigate` method to perform movements using `robot_move`.
- Decouple the measurement scheduler from `NavigationController` into `MeasurementScheduler`.