### PR TITLE
[WIP] Add settings and tasks to VS Code project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__
 *.sw*
 tags
 .idea
-.vscode
 
 # Packaging detritus
 *.egg

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "restructuredtext.confPath": "docs/conf.py",
+  "python.formatting.provider": "black",
+  // "python.testing.pytestEnabled": true,
+  // "python.testing.pytestArgs": [
+  //     "tests"
+  // ],
+
+  // isort
+  // rstcheck
+  // docformatter
+  // flake8
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,14 @@
     {
       "type": "shell",
       "command": "${command:python.interpreterPath}",
+      "args": ["setup.py", "sdist"],
+      "isBackground": true,
+      "options": {"cwd": "${workspaceFolder}"},
+      "label": "Build Source",
+    },
+    {
+      "type": "shell",
+      "command": "${command:python.interpreterPath}",
       "args": ["setup.py", "bdist_wheel", "sdist"],
       "isBackground": true,
       "options": {"cwd": "${workspaceFolder}"},
@@ -11,7 +19,20 @@
       "group": {
         "kind": "build",
         "isDefault": true
-      }
-    }
+      },
+      "dependsOn": ["Build Source"]
+    },
+    // {
+    //   "type": "shell",
+    //   "command": "tox",
+    //   "args": [],
+    //   "isBackground": false,
+    //   "options": {"cwd": "${workspaceFolder}"},
+    //   "label": "Run tox",
+    //   "group": {
+    //       "kind": "test",
+    //       "isDefault": true
+    //   }
+    // }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "command": "${command:python.interpreterPath}",
+      "args": ["setup.py", "bdist_wheel", "sdist"],
+      "isBackground": true,
+      "options": {"cwd": "${workspaceFolder}"},
+      "label": "Build Wheel",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Following [this guide](https://realpython.com/advanced-visual-studio-code-python/#testing-your-python-code-in-visual-studio-code), it was suggested to offer commonly useful tasks/settings for VS Code to source code. This is an example of what that might look like.