### PR TITLE
Filter devices connected to a pi-top by network

### DIFF
--- a/pitop/common/sys_info.py
+++ b/pitop/common/sys_info.py
@@ -1,6 +1,7 @@
 import subprocess
 from fractions import Fraction
 from os import path, uname
+from typing import Dict
 
 import netifaces
 from isc_dhcp_leases import IscDhcpLeases
@@ -10,19 +11,19 @@ from pitop.common.command_runner import run_command
 _, _, _, _, machine = uname()
 
 
-def is_pi():
+def is_pi() -> bool:
     return machine in ("armv7l", "aarch64")
 
 
-def get_uname_release():
+def get_uname_release() -> str:
     return uname().release
 
 
-def get_uname_version():
+def get_uname_version() -> str:
     return uname().version
 
 
-def get_debian_version():
+def get_debian_version() -> str:
     debian_version_file = "/etc/debian_version"
     if not path.exists(debian_version_file):
         return None
@@ -31,7 +32,7 @@ def get_debian_version():
     return content.strip()
 
 
-def get_maj_debian_version():
+def get_maj_debian_version() -> str:
     version = None
     with open("/etc/os-release", "r") as f:
         for line in f:
@@ -50,7 +51,7 @@ def get_maj_debian_version():
         return None
 
 
-def get_network_strength(iface):
+def get_network_strength(iface) -> str:
     strength = -1
     try:
         response_str = str(subprocess.check_output(["iwconfig", iface]).decode("utf-8"))
@@ -66,7 +67,7 @@ def get_network_strength(iface):
     return str(strength) + "%"
 
 
-def get_wifi_network_ssid():
+def get_wifi_network_ssid() -> str:
     try:
         network_id = str(
             subprocess.check_output(["iwgetid", "-r"]).decode("utf-8")
@@ -77,7 +78,7 @@ def get_wifi_network_ssid():
     return network_id
 
 
-def get_internal_ip(iface="wlan0"):
+def get_internal_ip(iface="wlan0") -> str:
     if iface not in netifaces.interfaces():
         return iface + " Not Found"
 
@@ -99,7 +100,7 @@ def get_internal_ip(iface="wlan0"):
     return internal_ip
 
 
-def start_systemd_service(service_name: str):
+def start_systemd_service(service_name: str) -> None:
     try:
         run_command(
             f"systemctl start {service_name}", timeout=20, check=True, log_errors=False
@@ -108,7 +109,7 @@ def start_systemd_service(service_name: str):
         pass
 
 
-def stop_systemd_service(service_name: str):
+def stop_systemd_service(service_name: str) -> None:
     try:
         run_command(
             f"systemctl stop {service_name}", timeout=20, check=False, log_errors=False
@@ -117,7 +118,7 @@ def stop_systemd_service(service_name: str):
         pass
 
 
-def get_systemd_active_state(service_name: str):
+def get_systemd_active_state(service_name: str) -> str:
     try:
         state = run_command(
             f"systemctl is-active {service_name}", timeout=10, log_errors=False
@@ -129,7 +130,7 @@ def get_systemd_active_state(service_name: str):
         return state
 
 
-def get_systemd_enabled_state(service_to_check: str):
+def get_systemd_enabled_state(service_to_check: str) -> str:
     try:
         state = str(
             subprocess.check_output(
@@ -144,22 +145,22 @@ def get_systemd_enabled_state(service_to_check: str):
         return state.strip().capitalize()
 
 
-def get_ssh_enabled_state():
+def get_ssh_enabled_state() -> bool:
     ssh_enabled_state = get_systemd_enabled_state("ssh")
     return ssh_enabled_state
 
 
-def get_vnc_enabled_state():
+def get_vnc_enabled_state() -> bool:
     vnc_enabled_state = get_systemd_enabled_state("vncserver-x11-serviced.service")
     return vnc_enabled_state
 
 
-def get_pt_further_link_enabled_state():
+def get_pt_further_link_enabled_state() -> bool:
     vnc_enabled_state = get_systemd_enabled_state("further-link.service")
     return vnc_enabled_state
 
 
-def get_ap_mode_status():
+def get_ap_mode_status() -> Dict:
     key_lookup = {
         "State": "state",
         "Access Point Network SSID": "ssid",
@@ -180,7 +181,7 @@ def get_ap_mode_status():
     return data
 
 
-def interface_is_up(interface_name):
+def interface_is_up(interface_name: str) -> bool:
     operstate_file = "/sys/class/net/" + interface_name + "/operstate"
     if not path.exists(operstate_file):
         return False
@@ -215,7 +216,7 @@ def get_address_for_connected_device():
     return ""
 
 
-def get_address_for_ptusb_connected_device():
+def get_address_for_ptusb_connected_device() -> str:
     if interface_is_up("ptusb0"):
         return get_address_for_connected_device()
     return ""


### PR DESCRIPTION
The `get_address_for_connected_device` function is used to determine the IP address of devices connected to the pi-top using the display-port cable. The pi-top leases IP addresses to devices connected in that port, so the check is basically performed by reviewing the leased IPs and pinging them to check if the client is still connected.

Since the addition of AP mode, the pi-top now assign IPs in 2 different networks: `192.168.64.0/24` for the USB port and `192.168.90.0/24` for AP. This means that as it is right now, the `get_address_for_connected_device` function returns IPs for all connected devices, which is something we might still want, but unexpected responses might result if this function was used on applications that assume that the only connection method to the pi-top is through USB (I'm thinking about the `pt-miniscreen` package and `pt-os-web-portal` onboarding miniscreen app).

This PR updates the `get_address_for_connected_device` function in order to filter the connected devices based on a network, if provided, thus allowing us to get the correct connected device IP for the particular needs of our apps. It also updates the `get_address_for_ptusb_connected_device` function to use the new argument and adds `get_address_for_ap_connected_device` to directly find AP connected devices.

Also, added type hinting to all the functions in the `sys_info` file.