### PR TITLE
Add missing `distutils` dependency

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,3 +1,4 @@
+distutils python3-distutils; PEP386
 dlib python3-dlib; PEP386
 flask python3-flask; PEP386
 flask-cors python3-flask-cors; PEP386

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,6 @@ install_requires =
     isc_dhcp_leases >= 0.9.1
     # CLI management
     distutils >= 3.9.2
-    # DHCP leases
-    isc_dhcp_leases >= 0.9.1
     # Network interfaces
     netifaces >= 0.10.4
     # Journal logging

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,10 @@ install_requires =
     #############
     # DHCP leases
     isc_dhcp_leases >= 0.9.1
+    # CLI management
+    distutils >= 3.9.2
+    # DHCP leases
+    isc_dhcp_leases >= 0.9.1
     # Network interfaces
     netifaces >= 0.10.4
     # Journal logging


### PR DESCRIPTION
Used by the CLI. Unable to run `pi-top` command on Raspberry Pi OS Lite with `pi-topd` installed without recommended dependencies.

```
from distutils.util import strtobool
```
produces
```
ModuleNotFoundError: No module named 'distutils.util'
```

