### PR TITLE
Improve EncoderMotor class error messages

### DIFF
--- a/pitop/pma/encoder_motor.py
+++ b/pitop/pma/encoder_motor.py
@@ -204,6 +204,12 @@ class EncoderMotor(Stateful, Recreatable):
         :param total_rotations:
             Total number of rotations to be execute. Set to 0 to run indefinitely.
         """
+
+        if not (-self.max_rpm <= abs(target_rpm) <= self.max_rpm):
+            raise ValueError(
+                f"Target RPM value must be between {-self.max_rpm} and {self.max_rpm} (inclusive)"
+            )
+
         dc_motor_rpm = int(
             round(target_rpm * self.MMK_STANDARD_GEAR_RATIO)
             * self.__forward_direction

--- a/pitop/pma/encoder_motor_controller.py
+++ b/pitop/pma/encoder_motor_controller.py
@@ -122,6 +122,11 @@ class EncoderMotorController:
 
     @type_check
     def set_rpm_control(self, rpm: int) -> None:
+        if not (-self.MAX_DC_MOTOR_RPM <= rpm <= self.MAX_DC_MOTOR_RPM):
+            raise ValueError(
+                f"DC motor RPM value must be between {-self.MAX_DC_MOTOR_RPM} and {self.MAX_DC_MOTOR_RPM} (inclusive)"
+            )
+
         self.set_control_mode(MotorControlModes.MODE_1)
         self._mcu_device.write_word(
             self.registers[MotorRegisterTypes.MODE_1_RPM],
@@ -151,6 +156,11 @@ class EncoderMotorController:
 
     @type_check
     def set_rpm_with_rotations(self, rpm: int, rotations_to_complete: int) -> None:
+        if not (-self.MAX_DC_MOTOR_RPM <= rpm <= self.MAX_DC_MOTOR_RPM):
+            raise ValueError(
+                f"DC motor RPM value must be between {-self.MAX_DC_MOTOR_RPM} and {self.MAX_DC_MOTOR_RPM} (inclusive)"
+            )
+
         self.set_control_mode(MotorControlModes.MODE_2)
         list_to_send = split_into_bytes(
             rotations_to_complete, 2, signed=True, little_endian=True

--- a/pitop/pma/encoder_motor_controller.py
+++ b/pitop/pma/encoder_motor_controller.py
@@ -122,9 +122,9 @@ class EncoderMotorController:
 
     @type_check
     def set_rpm_control(self, rpm: int) -> None:
-        if not (-self.MAX_DC_MOTOR_RPM <= rpm <= self.MAX_DC_MOTOR_RPM):
+        if not (-self._MAX_DC_MOTOR_RPM <= rpm <= self._MAX_DC_MOTOR_RPM):
             raise ValueError(
-                f"DC motor RPM value must be between {-self.MAX_DC_MOTOR_RPM} and {self.MAX_DC_MOTOR_RPM} (inclusive)"
+                f"DC motor RPM value must be between {-self._MAX_DC_MOTOR_RPM} and {self._MAX_DC_MOTOR_RPM} (inclusive)"
             )
 
         self.set_control_mode(MotorControlModes.MODE_1)
@@ -156,9 +156,9 @@ class EncoderMotorController:
 
     @type_check
     def set_rpm_with_rotations(self, rpm: int, rotations_to_complete: int) -> None:
-        if not (-self.MAX_DC_MOTOR_RPM <= rpm <= self.MAX_DC_MOTOR_RPM):
+        if not (-self._MAX_DC_MOTOR_RPM <= rpm <= self._MAX_DC_MOTOR_RPM):
             raise ValueError(
-                f"DC motor RPM value must be between {-self.MAX_DC_MOTOR_RPM} and {self.MAX_DC_MOTOR_RPM} (inclusive)"
+                f"DC motor RPM value must be between {-self._MAX_DC_MOTOR_RPM} and {self._MAX_DC_MOTOR_RPM} (inclusive)"
             )
 
         self.set_control_mode(MotorControlModes.MODE_2)


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready| [Ticket](https://pi-top.atlassian.net/browse/SWE-10) |


#### Main changes

Error message when setting `EncoderMotor` RPMs to a value higher than maximum was confusing, since the error mentioned a maximum RPM of 6000. This is because the error is talking about the about the output of the DC motor (before the reduction gears) and not the encoder motor / wheel output.

This PR implements changes that will improve the error message by displaying the actual maximum/minimum values that the class can handle as target RPM (~114 instead of ~6000).

#### Screenshots (feature, test output, profiling, dev tools etc)

N/A

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
- Install artifacts in your pi-top[4].
- Connect the pi-top[4] to an Expansion Plate.
- Instantiate a `EncoderMotor` object and try to set the target RPM with a value higher than 114, which is the maximum:
```
>>> from pitop import EncoderMotor
>>> motor = EncoderMotor("M0", forward_direction=1)
>>> motor.set_target_rpm(200)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/pi-top-Python-SDK/pitop/pma/encoder_motor.py", line 209, in set_target_rpm
    raise ValueError(
ValueError: Target RPM value must be between -114 and 114 (inclusive)
>>> motor.set_target_rpm(144) # should start moving since the target is in range
>>> motor.set_target_rpm(-200)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/pi-top-Python-SDK/pitop/pma/encoder_motor.py", line 209, in set_target_rpm
    raise ValueError(
ValueError: Target RPM value must be between -114 and 114 (inclusive)
>>> motor.set_target_rpm(0) # should stop moving
```

#### Tag anyone who definitely needs to review or help
-
