### PR TITLE
Remove 'distutils' dependency

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,4 +1,3 @@
-distutils python3-distutils; PEP386
 dlib python3-dlib; PEP386
 flask python3-flask; PEP386
 flask-cors python3-flask-cors; PEP386

--- a/pitopcli/support_core/health_check.py
+++ b/pitopcli/support_core/health_check.py
@@ -1,4 +1,3 @@
-from distutils.util import strtobool
 from os import uname
 from time import strftime
 
@@ -20,7 +19,7 @@ from .ptsoftware import PitopSoftware
 
 
 def str_to_bool(value):
-    return strtobool(value) == 0
+    return str(value) == "0"
 
 
 class HealthCheck:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,6 @@ install_requires =
     #############
     # DHCP leases
     isc_dhcp_leases >= 0.9.1
-    # CLI management
-    distutils >= 3.9.2
     # Network interfaces
     netifaces >= 0.10.4
     # Journal logging


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1263) |


#### Main changes

Package `distutils` isn't pip-installable, causing issues when trying to install the SDK in editable mode. 

Since `distutils` is only used to convert a string to a boolean, it's easy to replace with basic operations. My guess is that it was used for more complex command parsing but now it's only parsing the output of `raspi-config nonint` commands, which only outputs 0 or 1.

#### Screenshots (feature, test output, profiling, dev tools etc)

N/A

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
