### PR TITLE
Re-add class reference to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@
 
 import importlib.util
 import os
+import sys
 
 # -- Path setup --------------------------------------------------------------
 
@@ -16,6 +17,7 @@ import os
 #
 HERE = os.path.abspath(os.path.dirname(__file__))
 PARENT = os.path.dirname(HERE)
+sys.path.append(PARENT)
 
 # -- Project information -----------------------------------------------------
 
@@ -30,7 +32,7 @@ spec.loader.exec_module(modulevar)
 project = "pitop"
 author = "pi-top (CEED Ltd)"
 release = modulevar.__version__
-copyright = "pi-top 2021"
+copyright = "pi-top 2022"
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1248) |


#### Main changes
Include class references to docs. This is done by adding the `pitop` module to `sys.path` when building the docs.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips

Build the docs locally with:
```
# Install dependencies
pip3 install sphinx sphinx_rtd_theme
pip3 install -r docs/requirements.txt
# Remove any existing build
rm -r build
# Build
sphinx-build -W -v -bhtml docs/ build/html
```

And check the local build opening `docs/build/html/index.html`. You can check that the class references are now included by navigating through the docs.

#### Tag anyone who definitely needs to review or help
-
