### PR TITLE
Use PAT when creating a Github release

### DIFF
--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -85,3 +85,4 @@ jobs:
           draft: false
           prerelease: false
           files: ./artifacts/*
+          token: ${{ secrets.PAT_GITHUB }}

--- a/.github/workflows/deploy-python-release-on-publish.yml
+++ b/.github/workflows/deploy-python-release-on-publish.yml
@@ -1,9 +1,6 @@
 name: Deploy Published Python Release
 
 on:
-  push:
-    branches:
-      - "ci-test-publish-release-*"
   release:
     types:
       - published


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/SWE-43) |


#### Main changes
Use PAT instead of the default Github Token when creating a release. This allows the action to trigger other actions, as documented in https://docs.github.com/en/actions/security-guides/automatic-token-authentication

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
