### PR TITLE
Automatically create release on changelog PR merge

### DIFF
--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
     branches:
       - master
+  pull_request:
+    branches:
+      - bump-changelog
+    types: [closed]
+
 
 env:
   DEB_BUILD_DOCKER_IMAGE: "pitop/pi-top-os-deb-build"
@@ -15,6 +20,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.4.0


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1302) |


#### Main changes

Github releases are now automatically triggered when the 'bump-changelog' pull request is merged. The workflow can still be triggered manually via the 'Actions' tab.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
