### PR TITLE
fix: sudden exit caused by pyinotify.Notifier.loop daemonize option

### DIFF
--- a/pitop/miniscreen/oled/core/lock.py
+++ b/pitop/miniscreen/oled/core/lock.py
@@ -31,7 +31,7 @@ class MiniscreenLockFileMonitor:
         wm = WatchManager()
         wm.add_watch(self.lock_path, events_to_watch)
         self.notifier = Notifier(wm, eh)
-        self.notifier.loop(daemonize=True)
+        self.notifier.loop()
 
     def start(self):
         self.stop()


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | [Ticket](https://pi-top.atlassian.net/browse/OS-1331) |


#### Main changes
- Reverts part of 84be118 from #536.
The daemonize option os._exits the thread,
causing applications using it (eg pt-miniscreen) to suddenly exit. We
don't need to use the daemonize option since we are already running
Notifier.loop in a daemon thread.

https://github.com/seb-m/pyinotify/blob/0f3f8950d12e4a6534320153eed1a90a778da4ae/python3/pyinotify.py#L1316-L1317

#### Manual testing tips
- If you use the current SDK master when running pt-miniscreen, it will suddenly exit on the first run. Subsequent runs succeed only because the daemonize option errors out before exiting due to the lockfile already existing.