### PR TITLE
Specify camera backend on cv.VideoCapture

### DIFF
--- a/pitop/camera/core/cameras/usb_camera.py
+++ b/pitop/camera/core/cameras/usb_camera.py
@@ -33,7 +33,8 @@ class UsbCamera:
             self._rotate_angle = rotate_angle
 
         def create_camera_object(index, resolution=None):
-            cap = import_opencv().VideoCapture(index)
+            cv = import_opencv()
+            cap = cv.VideoCapture(index, cv.CAP_V4L2)
             if resolution is not None:
                 cap.set(3, resolution[0])
                 cap.set(4, resolution[1])

--- a/pitop/camera/core/cameras/usb_camera.py
+++ b/pitop/camera/core/cameras/usb_camera.py
@@ -34,7 +34,18 @@ class UsbCamera:
 
         def create_camera_object(index, resolution=None):
             cv = import_opencv()
-            cap = cv.VideoCapture(index, cv.CAP_V4L2)
+            try:
+                # Force V4L2 backend first to avoid warning logs
+                cap = cv.VideoCapture(index, cv.CAP_V4L2)
+            except Exception:
+                cap = None
+
+            # Retry using default backend on failure.
+            # Check if device is opened since sometimes VideoCapture
+            # doesn't raise an Exception on error
+            if cap is None or not cap.isOpened():
+                cap = cv.VideoCapture(index)
+
             if resolution is not None:
                 cap.set(3, resolution[0])
                 cap.set(4, resolution[1])


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1173) |

Closes  #495 

#### Main changes

Specify the `V4L2` backend for the USB camera capture object, which tells the video capture object that the cameras support capturing via `libv4l`. The default value `CAP_ANY` would probe the device to determine the correct backend to use, one of them being `CAP_GSTREAMER`, which prints the warning messages when unable to initialize.

The list of available backends can be found [here](https://docs.opencv.org/4.x/d4/d15/group__videoio__flags__base.html#ga023786be1ee68a9105bf2e48c700294d). Also, [this](https://docs.opencv.org/4.x/d0/da7/videoio_overview.html) is an interesting read. 

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
