### PR TITLE
Detect and raise exception when IMU is used with new Expansion Plate

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Depends:
 # Miniscreen fonts
  fonts-roboto,
  ttf-bitstream-vera,
- i2c-tools,
+ i2c-tools-extra,
 # 'ping' command
  iputils-ping,
 # Required for hub communication; such as getting case button state

--- a/pitop/pma/imu_controller.py
+++ b/pitop/pma/imu_controller.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from pitop.common.firmware_device import DeviceInfo
+from pitop.common.i2c_device import I2CDevice
+
 from .common.imu_registers import (
     ImuRegisters,
     MagCalHardTypes,
@@ -23,6 +26,11 @@ class ImuController:
     __SOFT_IRON_SCALE_FACTOR = 1000.0
 
     def __init__(self):
+        i2c_device = I2CDevice("/dev/i2c-1", 0x04)
+        i2c_device.connect()
+        if i2c_device.read_unsigned_byte(DeviceInfo.ID__SCH_REV_MAJOR) == 4:
+            raise Exception("This Expansion Plate doesn't have an IMU")
+
         self.__data_registers = ImuRegisters.DATA
         self.__enable_registers = ImuRegisters.ENABLE
         self.__config_registers = ImuRegisters.CONFIG

--- a/pitop/pma/imu_controller.py
+++ b/pitop/pma/imu_controller.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from pitop.common.firmware_device import DeviceInfo
-from pitop.common.i2c_device import I2CDevice
+from pitop.common.firmware_device import FirmwareDevice, FirmwareDeviceID
 
 from .common.imu_registers import (
     ImuRegisters,
@@ -26,9 +25,8 @@ class ImuController:
     __SOFT_IRON_SCALE_FACTOR = 1000.0
 
     def __init__(self):
-        i2c_device = I2CDevice("/dev/i2c-1", 0x04)
-        i2c_device.connect()
-        if i2c_device.read_unsigned_byte(DeviceInfo.ID__SCH_REV_MAJOR) == 4:
+        device = FirmwareDevice(FirmwareDeviceID.pt4_expansion_plate)
+        if device.get_sch_hardware_version_major() == 4:
             raise Exception("This Expansion Plate doesn't have an IMU")
 
         self.__data_registers = ImuRegisters.DATA

--- a/pitop/system/device.py
+++ b/pitop/system/device.py
@@ -49,7 +49,7 @@ def device_firmware(device_id):
     device_address = device_info.get("i2c_addr")
 
     fw_version = None
-    if getstatusoutput(f"pt-i2cdetect {device_address}"):
+    if getstatusoutput(f"i2cping {device_address}"):
         try:
             fw_device = FirmwareDevice(fw_device_id)
             fw_version = fw_device.get_fw_version()

--- a/pitopcli/imu.py
+++ b/pitopcli/imu.py
@@ -33,7 +33,7 @@ class ImuCLI(CliBaseClass):
         i2c_address = expansion_plate_info.get("i2c_addr")
         try:
             expansion_plate_connected = (
-                getstatusoutput(f"pt-i2cdetect {i2c_address}")[0] == 0
+                getstatusoutput(f"i2cping {i2c_address}")[0] == 0
             )
         except Exception:
             expansion_plate_connected = False


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1322) |


#### Main changes
- Raise an Exception when trying to use the IMU on latest Expansion Plate.
- Replace usage of `pt-i2cdetect` (now deprecated) with `i2cping`.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
