### PR TITLE
Depend on numpy>1.19.5 when pip-installing

### DIFF
--- a/packages/camera/setup.py
+++ b/packages/camera/setup.py
@@ -46,9 +46,9 @@ __requires__ = [
     f"pitop.pma=={__version__}",
     f"pitop.processing=={__version__}",
     "imageio>=2.4.1,<3.0.0",
-    "numpy>=1.19.5,<2.0.0",
+    "numpy>1.19.5,<2.0.0",
     "Pillow>=8.1.2,<9.0.0",
-    "opencv-python>=4.5.1,<5.0.0",
+    "opencv-python>=4.5.1,<4.6.0",
 ]
 
 

--- a/packages/cli/setup.py
+++ b/packages/cli/setup.py
@@ -48,7 +48,8 @@ __requires__ = [
     f"pitop.pma=={__version__}",
     f"pitop.miniscreen=={__version__}",
     "netifaces>=0.10.4,<1.0.0",
-    "numpy>=1.19.5,<2.0.0",
+    "numpy>1.19.5,<2.0.0",
+    "numpy>1.19.5,<2.0.0",
     "matplotlib>=3.3.4,<4.0.0",
     "scipy>=1.6.0,<2.0",
 ]

--- a/packages/core/setup.py
+++ b/packages/core/setup.py
@@ -43,8 +43,8 @@ __keywords__ = [
 __requires__ = [
     f"pitop.common=={__version__}",
     "Pillow>=8.1.2,<9.0",
-    "numpy>=1.19.5,<2.0.0",
-    "opencv-python>=4.5.1,<5.0.0",
+    "numpy>1.19.5,<2.0.0",
+    "opencv-python>=4.5.1,<4.6.0",
 ]
 
 

--- a/packages/pma/setup.py
+++ b/packages/pma/setup.py
@@ -43,8 +43,8 @@ __keywords__ = [
 __requires__ = [
     f"pitop.common=={__version__}",
     f"pitop.core=={__version__}",
-    "gpiozero>=1.6.2,<2.0",
-    "numpy>=1.19.5,<2.0",
+    "gpiozero>=1.6.2,<2.0.0",
+    "numpy>1.19.5,<2.0.0",
 ]
 
 

--- a/packages/processing/setup.py
+++ b/packages/processing/setup.py
@@ -46,9 +46,9 @@ __requires__ = [
     f"pitop.core=={__version__}",
     "imutils>=0.5.4,<1.0.0",
     "matplotlib>=3.3.4,<4.0",
-    "numpy>=1.19.5,<2.0",
+    "numpy>1.19.5,<2.0.0",
     "onnxruntime>=1.8.1,<2.0",
-    "opencv-python>=4.5.1,<5.0.0",
+    "opencv-python>=4.5.1,<4.6.0",
     "wget>=3.2,<4.0",
     #############################
     # Advanced image processing #

--- a/packages/robotics/setup.py
+++ b/packages/robotics/setup.py
@@ -44,8 +44,8 @@ __requires__ = [
     f"pitop.system=={__version__}",
     f"pitop.pma=={__version__}",
     f"pitop.core=={__version__}",
-    "numpy>=1.19.5,<2.0",
-    "scipy>=1.6.0,<2.0",
+    "numpy>1.19.5,<2.0.0",
+    "scipy>=1.6.0,<2.0.0",
 ]
 
 


### PR DESCRIPTION
#### Main changes
When pip installing a subpackage in Raspberry Pi OS, we used the already installed `numpy` package, version `1.19.5`, which was the version we wanted to install. However, this error came up when trying to import `cv2`:
```
>>> import cv2
RuntimeError: module compiled against API version 0xf but this version of numpy is 0xd
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/.local/lib/python3.9/site-packages/cv2/__init__.py", line 8, in <module>
    from .cv2 import *
ImportError: numpy.core.multiarray failed to import
```
After reading this [useful explanation](https://stackoverflow.com/a/49756785), it seems that we need to use a newer version of  `numpy`. 

Note: This is not an issue when installing the subpackages using the `deb` files.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
