### PR TITLE
Fix name of pitopcli package

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -15,9 +15,9 @@ netifaces python3-netifaces; PEP386
 # Numpy in Debian has epoch version 1
 numpy python3-numpy; s/^/1:/
 opencv-python python3-opencv; PEP386
+pitop python3-pitop
 pitop.battery python3-pitop-battery
 pitop.camera python3-pitop-camera
-pitop.cli python3-pitop-cli
 pitop.common python3-pitop-common
 pitop.core python3-pitop-core
 pitop.display python3-pitop-display
@@ -28,7 +28,7 @@ pitop.processing python3-pitop-processing
 pitop.robotics python3-pitop-robotics
 pitop.system python3-pitop-system
 pitop.simulation python3-pitop-simulation
-pitop python3-pitop
+pitopcli python3-pitop-cli
 pyinotify python3-pyinotify; PEP386
 RPi.GPIO python3-rpi.gpio; PEP386
 scipy python3-scipy; PEP386

--- a/packages/pitop/setup.py
+++ b/packages/pitop/setup.py
@@ -51,7 +51,6 @@ __requires__ = [
     ###############
     f"pitop.battery=={__version__}",
     f"pitop.camera=={__version__}",
-    f"pitop.cli=={__version__}",
     f"pitop.common=={__version__}",
     f"pitop.core=={__version__}",
     f"pitop.display=={__version__}",
@@ -62,6 +61,7 @@ __requires__ = [
     f"pitop.robotics=={__version__}",
     f"pitop.simulation=={__version__}",
     f"pitop.system=={__version__}",
+    f"pitopcli=={__version__}",
     #########
     # PROTO #
     #########


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready | no Ticket |


#### Main changes
- pip install pitop was failing for me due to a dependency on 'pitop.cli' when the package is published as 'pitopcli'
- also update the name in the debian dist overrides

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
