### PR TITLE
Reset miniscreen after pi-topd is initialized

### DIFF
--- a/packages/common/pitop/common/ptdm.py
+++ b/packages/common/pitop/common/ptdm.py
@@ -414,7 +414,7 @@ class PTDMSubscribeClient:
     def __init__(self):
         self.__thread = Thread(target=self.__thread_method, daemon=True)
 
-        self.__callback_funcs = None
+        self._callback_funcs = None
 
         self._zmq_context = None
         self._zmq_socket = None
@@ -463,9 +463,9 @@ class PTDMSubscribeClient:
                 message = Message.from_string(message_string)
 
                 id = message.message_id()
-                if id in self.__callback_funcs:
+                if id in self._callback_funcs:
                     self.invoke_callback_func_if_exists(
-                        self.__callback_funcs[id], message.parameters
+                        self._callback_funcs[id], message.parameters
                     )
 
     def invoke_callback_func_if_exists(self, func, params=list()):
@@ -485,7 +485,7 @@ class PTDMSubscribeClient:
             func(params)
 
     def initialise(self, callback_funcs):
-        self.__callback_funcs = callback_funcs
+        self._callback_funcs = callback_funcs
 
     def start_listening(self):
         if not self.__connect_to_socket():

--- a/packages/common/pitop/common/ptdm.py
+++ b/packages/common/pitop/common/ptdm.py
@@ -177,6 +177,7 @@ class Message:
     PUB_FAILED_KEYBOARD_CONNECT = 324
     PUB_OLED_CONTROL_CHANGED = 325
     PUB_OLED_SPI_BUS_CHANGED = 326
+    PUB_PITOPD_READY = 327
 
     __message_names[PUB_BRIGHTNESS_CHANGED] = "PUB_BRIGHTNESS_CHANGED"
     __message_names[PUB_PERIPHERAL_CONNECTED] = "PUB_PERIPHERAL_CONNECTED"
@@ -205,6 +206,7 @@ class Message:
     __message_names[PUB_FAILED_KEYBOARD_CONNECT] = "PUB_FAILED_KEYBOARD_CONNECT"
     __message_names[PUB_OLED_CONTROL_CHANGED] = "PUB_OLED_CONTROL_CHANGED"
     __message_names[PUB_OLED_SPI_BUS_CHANGED] = "PUB_OLED_SPI_BUS_CHANGED"
+    __message_names[PUB_PITOPD_READY] = "PUB_PITOPD_READY"
 
     __param_types[PUB_BRIGHTNESS_CHANGED] = [int]
     __param_types[PUB_PERIPHERAL_CONNECTED] = [int]
@@ -233,6 +235,7 @@ class Message:
     __param_types[PUB_FAILED_KEYBOARD_CONNECT] = list()
     __param_types[PUB_OLED_CONTROL_CHANGED] = [int]
     __param_types[PUB_OLED_SPI_BUS_CHANGED] = [int]
+    __param_types[PUB_PITOPD_READY] = list()
 
     def _parse(self, message_string):
         message_parts = message_string.split("|")

--- a/tests/test_oled.py
+++ b/tests/test_oled.py
@@ -275,3 +275,27 @@ def test_display_multiline_text_with_newlines(oled, snapshot, fonts_mock):
     text = "Line1\nLine2\nLine3\nLine4"
     oled.display_multiline_text(text)
     snapshot.assert_match(to_bytes(oled.image), "defaults.png")
+
+
+def test_subscribes_to_pitopd_ready_event(oled):
+    from pitop.common.ptdm import Message
+
+    callback = oled._ptdm_subscribe_client._callback_funcs.get(Message.PUB_PITOPD_READY)
+    assert callback is not None
+
+
+def test_on_pitopd_initialization_callback(oled):
+    from pitop.common.ptdm import Message
+
+    oled.display_image = Mock()
+    oled.reset = Mock()
+
+    callback = oled._ptdm_subscribe_client._callback_funcs.get(Message.PUB_PITOPD_READY)
+
+    assert oled.display_image.call_count == 0
+    assert oled.reset.call_count == 0
+
+    callback()
+
+    assert oled.display_image.call_count == 1
+    assert oled.reset.call_count == 1


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1379) |


#### Main changes

Add new `PUB_PITOPD_READY` message to be handled by `pi-topd` when it's initialized.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
