### PR TITLE
Update detection of pi user default password

### DIFF
--- a/packages/common/pitop/common/pt_os.py
+++ b/packages/common/pitop/common/pt_os.py
@@ -84,7 +84,7 @@ def is_pi_using_default_password():
     if getuser() == "root":
         with open("/etc/shadow") as shadow_file:
             for line in shadow_file:
-                if "pi:" in line and "c4XjD2pO7T6KeaTJXLMFZ/" in line:
+                if "pi:" in line and "SomeSalt" in line:
                     return True
 
         return False


### PR DESCRIPTION
#### Main changes

Update detection of `pi` user default password; since pi-topOS is now built on top of the latest Raspberry Pi image, we manually set the username and password; this PR updates the text that is looked up in `/etc/shadow` based on [this](https://github.com/pi-top/pi-topOS-Build/blob/master/playbooks/configure_pi_top_os.yml#L19)

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
