### PR TITLE
Handle errors when reading leased IPs

### DIFF
--- a/packages/common/pitop/common/sys_info.py
+++ b/packages/common/pitop/common/sys_info.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Enum, auto
 from fractions import Fraction
 from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
@@ -9,6 +10,8 @@ import netifaces
 from isc_dhcp_leases import IscDhcpLeases
 
 from pitop.common.command_runner import run_command
+
+logger = logging.getLogger(__name__)
 
 
 class NetworkInterface(Enum):
@@ -215,7 +218,14 @@ def get_address_for_connected_device(
         except Exception:
             return False
 
-    current_leases = IscDhcpLeases("/var/lib/dhcp/dhcpd.leases").get_current().values()
+    try:
+        current_leases = (
+            IscDhcpLeases("/var/lib/dhcp/dhcpd.leases").get_current().values()
+        )
+    except Exception as e:
+        logger.error(f"Error reading dhcpd leases: {e}")
+        return ""
+
     current_leases = list(current_leases)
     current_leases.reverse()
 


### PR DESCRIPTION
#### Main changes

On first boot we continuously try to get the IP address of connected devices via USB or AP. This sometimes fails because the file with the leases doesn't exist yet. 
The changes in this PR handle that case, returning an empty string, which means that no IP lease exist at the moment.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
