### PR TITLE
Build Docker image for running tests

### DIFF
--- a/.github/workflows/test-runner-docker-builder.yml
+++ b/.github/workflows/test-runner-docker-builder.yml
@@ -1,0 +1,60 @@
+name: pi-topOS Docker Base Image Build
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "tests/Dockerfile"
+      - "tests/requirements.txt"
+      - ".github/workflows/test-runner-docker-builder.yml"
+
+env:
+  IMAGE_NAME: "pitop/sdk-test-runner"
+  PLATFORMS: "linux/amd64"
+
+jobs:
+  build-push-docker-hub:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          install: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: latest=true
+          tags: |
+            type=ref,event=branch
+
+      - name: Build and push
+        id: docker_build_push
+        uses: docker/build-push-action@v2
+        with:
+          context: tests
+          file: tests/Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Show image digest
+        run: echo ${{ steps.docker_build_push.outputs.digest }}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,12 +2,17 @@ FROM ubuntu:20.04
 
 COPY requirements.txt /tmp/
 
+env DISPLAY=":0"
+
 RUN apt update
 
 RUN DEBIAN_FRONTEND=noninteractive apt install -y \
     python3 \
     python3-pip \
     cmake \
-    python3-opencv
+    python3-opencv \
+    xvfb
 
 RUN pip3 install -r /tmp/requirements.txt
+
+CMD bash -c "Xvfb -ac :0 -screen 0 1280x1024x24 > /dev/null 2>&1 &"

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,29 +2,49 @@
 
 ## Running the tests
 
-To run the tests, install the dependencies declared in `requirements.txt`. Then, you can run the tests with `pytest`.
+To run the tests in your machine, install the dependencies declared in `requirements.txt` and the `xvfb` package, needed to start a virtual display. Then, you can run the tests with `pytest`.
 
 ```
+$ sudo apt update
+$ sudo apt install -y xvfb
 $ pip3 install -r tests/requirements.txt
+$ export DISPLAY=:0
+$ Xvfb -ac :0 -screen 0 1280x1024x24 > /dev/null 2>&1 &
 $ pytest --verbose
 ```
 
 ## Using docker
 
-Since it can take a while to download or build the dependencies, you can create a docker image with these pre-loaded. We provide a `Dockerfile` to build an image that can be used to run the tests.
+Since it can take a while to download or build the dependencies, you can create a docker image with these pre-loaded. We provide a `Dockerfile` to build an image that can be used to run the tests. We also provide images you can use to run the tests directly.
 
-Build the image by running:
-```
-$ cd tests
-$ docker build -t sdk-test-runner .
-```
+### Using pi-top test runner image
 
-Then, run the tests with:
 ```
 $ docker run \
     --rm \
     -it \
-    --volume "$PWD/..":/sdk \
+    --volume "$PWD":/sdk \
+    --workdir /sdk \
+    --entrypoint=pytest \
+    pitop/sdk-test-runner \
+    --verbose
+```
+
+### Building the image
+
+Build the image by running:
+
+```
+$ docker build -t sdk-test-runner tests
+```
+
+Then, run the tests with:
+
+```
+$ docker run \
+    --rm \
+    -it \
+    --volume "$PWD":/sdk \
     --workdir /sdk \
     --entrypoint=pytest \
     sdk-test-runner \


### PR DESCRIPTION

#### Main changes

Add a workflow to build a docker image to run the tests locally. It can be used to run the tests locally with:

```
docker run \
    --rm \
    -it \
    --volume "$PWD":/sdk \
    --workdir /sdk \
    --entrypoint=pytest \
    pitop/sdk-test-runner \
    --verbose
```

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
