### PR TITLE
Add additional exports to the pitop and robotics modules

### DIFF
--- a/packages/pitop/pitop/__init__.py
+++ b/packages/pitop/pitop/__init__.py
@@ -4,8 +4,11 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 import pitop.simulation
 
 # System Devices
+from pitop.battery import Battery
 from pitop.camera import Camera
+from pitop.display import Display
 from pitop.keyboard import KeyboardButton
+from pitop.miniscreen import Miniscreen
 
 # PMA
 from pitop.pma import (
@@ -22,11 +25,11 @@ from pitop.pma import ServoMotorSetting
 from pitop.pma import ServoMotorSetting as ServoMotorState
 from pitop.pma import SoundSensor, UltrasonicSensor
 from pitop.pma.parameters import BrakingType, Direction, ForwardDirection
+
+# Robotics
 from pitop.robotics.blockpi_rover import BlockPiRover
 from pitop.robotics.configurations import AlexRobot  # deprecated
 from pitop.robotics.configurations import alex_config
-
-# Robotics
 from pitop.robotics.drive_controller import DriveController
 from pitop.robotics.navigation import NavigationController
 from pitop.robotics.pan_tilt_controller import PanTiltController

--- a/packages/robotics/pitop/robotics/__init__.py
+++ b/packages/robotics/pitop/robotics/__init__.py
@@ -1,0 +1,8 @@
+from .blockpi_rover import BlockPiRover
+from .configurations import AlexRobot  # deprecated
+from .configurations import alex_config
+from .drive_controller import DriveController
+from .navigation import NavigationController
+from .pan_tilt_controller import PanTiltController
+from .pincer_controller import PincerController
+from .tilt_roll_head_controller import TiltRollHeadController


### PR DESCRIPTION
These exports follow the existing pattern of exporting all the key interfaces from both their subpackage and the top-level package.

In particular this aims to fix the import of DriveController from pitop.robotics used the web-portal rover controller, which assumed this would be available when switching to use subpackages.

| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
-

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
