### PR TITLE
Get werkzeug version using importlib

### DIFF
--- a/packages/common/pitop/common/flask_sockets.py
+++ b/packages/common/pitop/common/flask_sockets.py
@@ -24,10 +24,12 @@ except ImportError:
 
 
 def should_patch():
-    import werkzeug
+    import importlib.metadata
+
     from packaging.version import Version
 
-    return Version(werkzeug.__version__) >= Version("2.0.0")
+    werkzeug_version = Version(importlib.metadata.version("werkzeug"))
+    return werkzeug_version >= Version("2.0.0")
 
 
 class SocketMiddleware(object):


### PR DESCRIPTION
#### Main changes
- Get `werkzeug` version from `importlib.metadata` instead of using the `__version__` property, which was removed in the latest versions of the package. This bit of code is used in the function that decides if the vendored sockets from `flask_sockets` for `bookworm` should be patched or not.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
