### PR TITLE
Add description content type on setup.py

### DIFF
--- a/.github/workflows/deploy-python-release-on-publish.yml
+++ b/.github/workflows/deploy-python-release-on-publish.yml
@@ -49,7 +49,16 @@ jobs:
           name: "dist"
           path: "./dist/*"
 
+      - name: Publish to TestPyPI
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TEST_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+
       - name: Publish to PyPI
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     - id: trailing-whitespace
       # debian/patches needs whitespace at end of line
@@ -29,18 +29,18 @@ repos:
       ]
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
     - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
     - id: black
 
 # https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
+    rev: 7.1.1
     hooks:
     - id: flake8
       args: [

--- a/packages/battery/setup.py
+++ b/packages/battery/setup.py
@@ -54,6 +54,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/camera/setup.py
+++ b/packages/camera/setup.py
@@ -61,6 +61,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/cli/setup.py
+++ b/packages/cli/setup.py
@@ -74,6 +74,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/common/setup.py
+++ b/packages/common/setup.py
@@ -68,6 +68,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/core/setup.py
+++ b/packages/core/setup.py
@@ -57,6 +57,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/display/setup.py
+++ b/packages/display/setup.py
@@ -54,6 +54,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/keyboard/setup.py
+++ b/packages/keyboard/setup.py
@@ -55,6 +55,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/miniscreen/setup.py
+++ b/packages/miniscreen/setup.py
@@ -60,6 +60,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/pitop/setup.py
+++ b/packages/pitop/setup.py
@@ -91,6 +91,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/pma/setup.py
+++ b/packages/pma/setup.py
@@ -58,6 +58,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/processing/setup.py
+++ b/packages/processing/setup.py
@@ -66,6 +66,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/robotics/setup.py
+++ b/packages/robotics/setup.py
@@ -58,6 +58,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/simulation/setup.py
+++ b/packages/simulation/setup.py
@@ -56,6 +56,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,

--- a/packages/system/setup.py
+++ b/packages/system/setup.py
@@ -56,6 +56,7 @@ def main():
             version=__version__,
             description=__doc__,
             long_description=readme.read(),
+            long_description_content_type="text/markdown",
             classifiers=__classifiers__,
             author=__author__,
             author_email=__author_email__,


### PR DESCRIPTION
#### Main changes
- Fix publishing packages to PyPI by setting the description content type.
- 'deploy' workflow uploads packages to test.pypi when ran manually, for testing purposes.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
