### PR TITLE
DriveController set synchronous mode on each movement

### DIFF
--- a/packages/robotics/pitop/robotics/drive_controller.py
+++ b/packages/robotics/pitop/robotics/drive_controller.py
@@ -60,7 +60,6 @@ class DriveController(Stateful, Recreatable):
 
         # Motor syncing
         self.__mcu_device = PlateInterface().get_device_mcu()
-        self._set_synchronous_motor_movement_mode()
 
         Stateful.__init__(self, children=["left_motor", "right_motor"])
         Recreatable.__init__(
@@ -78,6 +77,9 @@ class DriveController(Stateful, Recreatable):
             | MotorSyncBits[self.right_motor_port].value
         )
         self.__mcu_device.write_byte(MotorSyncRegisters.CONFIG.value, sync_config)
+
+    def _unset_synchronous_motor_movement_mode(self) -> None:
+        self.__mcu_device.write_byte(MotorSyncRegisters.CONFIG.value, 0b0000000)
 
     def _start_synchronous_motor_movement(self) -> None:
         self.__mcu_device.write_byte(MotorSyncRegisters.START.value, 1)
@@ -299,6 +301,7 @@ class DriveController(Stateful, Recreatable):
         if distance is None:
             # run indefinitely
             distance = 0.0
+        self._set_synchronous_motor_movement_mode()
         self.left_motor.set_target_speed(
             left_speed, distance=copysign(distance, left_speed)
         )
@@ -306,3 +309,4 @@ class DriveController(Stateful, Recreatable):
             right_speed, distance=copysign(distance, right_speed)
         )
         self._start_synchronous_motor_movement()
+        self._unset_synchronous_motor_movement_mode()


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes

The DriveController enables synchronous mode in its constructor, which causes issues when trying to use an EncoderMotor individually; this PR will enable synchronous mode for each movement of the DriveController and then disable it, allowing to use an EncoderMotor alongside the DriveController.

Sample snippet:

```
from pitop import DriveController

d = DriveController()
d.forward(0.5)
d.stop()

left_motor = d.left_motor

# this doesn't work right now
left_motor.set_target_rpm(144)
```

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips

#### Tag anyone who definitely needs to review or help
-
